### PR TITLE
:sparkles: feat: Add bridgeSendTransaction action

### DIFF
--- a/src/actions/wallet/bridgeSendTransaction.ts
+++ b/src/actions/wallet/bridgeSendTransaction.ts
@@ -1,0 +1,35 @@
+import {
+  Chain,
+  Transport,
+  Account,
+  WalletClient,
+  SendTransactionParameters,
+} from 'viem'
+import { writeContract } from 'viem/actions'
+import { l1CrossDomainMessengerABI } from '@eth-optimism/contracts-ts'
+import { OpChainL2, OpChainL1 } from '@roninjin10/rollup-chains'
+
+export async function bridgeSendTransaction<
+  TChainL1 extends OpChainL1 | undefined = OpChainL1,
+  TChainL2 extends OpChainL2 | undefined = OpChainL2,
+  TAccount extends Account | undefined = Account | undefined,
+  TChainOverride extends Chain | undefined = Chain | undefined,
+>(
+  client: WalletClient<Transport, OpChainL1>,
+  { toChain, to, data, value, l2Gas = BigInt(200_000), ...restArgs }: { toChain: TChainL2, l2Gas?: BigInt } & SendTransactionParameters<TChainL1, TAccount, TChainOverride>,
+
+) {
+  return writeContract(client, {
+    abi: l1CrossDomainMessengerABI,
+    address: toChain?.opContracts.L1CrossDomainMessengerProxy,
+    functionName: 'sendMessage' as any,
+    args: [
+      to,
+      data,
+      l2Gas,
+    ],
+    ...restArgs
+    // TODO better typescriptin
+  } as any)
+}
+

--- a/src/actions/wallet/bridgeWriteContract.ts
+++ b/src/actions/wallet/bridgeWriteContract.ts
@@ -8,18 +8,18 @@ import {
   EncodeFunctionDataParameters,
   WalletClient,
 } from 'viem'
-import { OpChainL2, OpChainL1 } from '@roninjin10/rollup-chains'
+import { OpChainL2 } from '@roninjin10/rollup-chains'
 import { bridgeSendTransaction } from './bridgeSendTransaction'
 
 export async function bridgeWriteContract<
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
   TChainL2 extends OpChainL2 = OpChainL2,
-  TChainL1 extends Chain & { id: TChainL2['l1']['id'] } = OpChainL1,
+  TChainL1 extends Chain & { id: TChainL2['l1']['id'] } = TChainL2["l1"],
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
 >(
-  client: WalletClient<Transport, TChainL1>,
+  client: WalletClient<Transport, TChainL2["l1"]>,
   // TODO Document wtf l2Gas is and maybe give it a better name
   { toChain, args, abi, address, functionName, l2Gas = BigInt(200_000), ...restArgs }: { toChain: TChainL2, l2Gas?: BigInt } & WriteContractParameters<TAbi, TFunctionName, TChainL1, TAccount, TChainOverride>,
 ): Promise<string> {

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -6,6 +6,7 @@ import {
   writeUnsafeDepositTransaction,
 } from '../actions/wallet/writeUnsafeDepositTransaction'
 import { optimismPortalABI } from '@eth-optimism/contracts-ts'
+import { bridgeSendTransaction } from '../actions/wallet/bridgeSendTransaction'
 
 /// NOTE We don't currently need account for exisiting actions but keeping in case
 // TODO need to add generics
@@ -30,6 +31,10 @@ export type WalletOpStackActions<
       TChainOverride
     >,
   ) => Promise<WriteContractReturnType>
+  bridgeSendTransaction: (
+    // TODO name these params
+    args: Parameters<typeof bridgeSendTransaction>[1],
+  ) => Promise<string>
 }
 
 export function walletOpStackActions<
@@ -40,9 +45,9 @@ export function walletOpStackActions<
   client: WalletClient<TTransport, TChain, TAccount>,
 ): WalletOpStackActions<TChain, TAccount> {
   return {
-    // TODO do better than as any
     bridgeWriteContract: (args) => bridgeWriteContract(client as any, args),
     writeUnsafeDepositTransaction: (args) =>
       writeUnsafeDepositTransaction(client, args),
+    bridgeSendTransaction: (args) => bridgeSendTransaction(client as any, args)
   }
 }


### PR DESCRIPTION
Add bridgeSendTransaction action
- The bridged version of https://viem.sh/docs/actions/wallet/sendTransaction.html
- Currently only handles deposits
- bridgeWriteContract is a convenience method on top of this for specifically calling a contract
  - e.g. viems [writeContract](https://viem.sh/docs/contract/writeContract.html) vs [sendTransaction](https://viem.sh/docs/actions/wallet/sendTransaction.html)