### PR TITLE
fix types for unsafeDeposit and add test

### DIFF
--- a/src/actions/public/getL2HashesForDepositTx.test.ts
+++ b/src/actions/public/getL2HashesForDepositTx.test.ts
@@ -2,6 +2,9 @@ import { test, expect } from 'vitest'
 import { createPublicClient, http } from 'viem'
 import { mainnet } from '@wagmi/chains'
 import { publicOpStackActions } from '../../decorators/publicOpStack'
+import { optimismPortalABI } from '../../generated/contracts'
+import { base } from '@roninjin10/rollup-chains'
+import { publicClient } from '../../_test/utils'
 
 test('correctly retrieves L2 hash', async () => {
   const client = createPublicClient({
@@ -19,4 +22,12 @@ test('correctly retrieves L2 hash', async () => {
   expect(hashes[0]).toEqual(
     '0xe67200042bf79eef76850dd3986bdd544e7aceeb7bbf8449158088bdc582168a',
   )
+
+  const c = await publicClient.readContract({
+    abi: optimismPortalABI,
+    address: base.opContracts.OptimismPortalProxy,
+    functionName: 'minimumGasLimit',
+    args: [10n],
+  })
+  console.log(c)
 })

--- a/src/actions/public/getL2HashesForDepositTx.test.ts
+++ b/src/actions/public/getL2HashesForDepositTx.test.ts
@@ -22,12 +22,4 @@ test('correctly retrieves L2 hash', async () => {
   expect(hashes[0]).toEqual(
     '0xe67200042bf79eef76850dd3986bdd544e7aceeb7bbf8449158088bdc582168a',
   )
-
-  const c = await publicClient.readContract({
-    abi: optimismPortalABI,
-    address: base.opContracts.OptimismPortalProxy,
-    functionName: 'minimumGasLimit',
-    args: [10n],
-  })
-  console.log(c)
 })

--- a/src/actions/wallet/writeUnsafeDepositTransaction.test.ts
+++ b/src/actions/wallet/writeUnsafeDepositTransaction.test.ts
@@ -7,8 +7,10 @@ import {
 import { base } from '@roninjin10/rollup-chains'
 import { accounts } from '../../_test/constants'
 import { mine } from 'viem/actions'
-import { encodeFunctionData } from 'viem'
+import { decodeEventLog, encodeFunctionData, encodePacked } from 'viem'
 import { optimismPortalABI } from '@eth-optimism/contracts-ts'
+import { getDepositEventsInfoFromTxReceipt } from '../../utils/getDepositEventsInfoFromTxReceipt'
+import { TransactionDepositedEvent } from '../../types/depositTx'
 
 test('default', async () => {
   expect(
@@ -16,10 +18,11 @@ test('default', async () => {
       args: {
         to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
         value: 1n,
-        gasLimit: 1n,
+        gasLimit: 25000n,
         data: '0x',
         isCreation: false,
       },
+      value: 0n,
       toChain: base,
       account: accounts[0].address,
     }),
@@ -31,10 +34,11 @@ test('sends transaction to correct address', async () => {
     args: {
       to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
       value: 1n,
-      gasLimit: 1n,
+      gasLimit: 25000n,
       data: '0x',
       isCreation: false,
     },
+    value: 1n,
     toChain: base,
     account: accounts[0].address,
   })
@@ -45,13 +49,46 @@ test('sends transaction to correct address', async () => {
   expect(r.to).toEqual(base.opContracts.OptimismPortalProxy.toLocaleLowerCase())
 })
 
-// TODO(wilson): consider deploying OP stack contracts to our anvil so that we can have better tests
+test('creates correct deposit transaction', async () => {
+  const args: DepositTransactionParameters = {
+    to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
+    value: 1n,
+    gasLimit: 25000n,
+    data: '0x',
+    isCreation: false,
+  }
+  const hash = await writeUnsafeDepositTransaction(walletClient, {
+    args,
+    value: args.value!,
+    toChain: base,
+    account: accounts[0].address,
+  })
+
+  await mine(testClient, { blocks: 1 })
+
+  const r = await publicClient.getTransactionReceipt({ hash })
+  expect(r.logs.length).toEqual(1)
+  const depositEvent = decodeEventLog({
+    abi: optimismPortalABI,
+    data: r.logs[0].data,
+    topics: r.logs[0].topics,
+  })
+  expect(depositEvent.eventName).toEqual('TransactionDeposited')
+  const deposit = depositEvent as TransactionDepositedEvent
+  expect(deposit.args.from.toLowerCase()).toEqual(accounts[0].address)
+  expect(deposit.args.to.toLowerCase()).toEqual(args.to)
+  const expectOpaqueData = encodePacked(
+    ['uint', 'uint', 'uint64', 'bool', 'bytes'],
+    [args.value!, args.value!, args.gasLimit, args.isCreation!, args.data!],
+  )
+  expect(deposit.args.opaqueData).toEqual(expectOpaqueData)
+})
 
 test('correctly passes arugments', async () => {
   const args: DepositTransactionParameters = {
     to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
     value: 1n,
-    gasLimit: 1n,
+    gasLimit: 25000n,
     data: '0x',
     isCreation: false,
   }
@@ -60,6 +97,7 @@ test('correctly passes arugments', async () => {
     args,
     toChain: base,
     account: accounts[0].address,
+    value: 0n,
   })
 
   await mine(testClient, { blocks: 1 })
@@ -77,13 +115,14 @@ test('correctly passes arugments', async () => {
 test('uses defaults for data, isCreation, and value', async () => {
   const args: DepositTransactionParameters = {
     to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
-    gasLimit: 1n,
+    gasLimit: 25000n,
   }
 
   const hash = await writeUnsafeDepositTransaction(walletClient, {
     args,
     toChain: base,
     account: accounts[0].address,
+    value: 0n,
   })
 
   await mine(testClient, { blocks: 1 })

--- a/src/actions/wallet/writeUnsafeDepositTransaction.ts
+++ b/src/actions/wallet/writeUnsafeDepositTransaction.ts
@@ -22,15 +22,13 @@ export type DepositTransactionParameters = {
 }
 
 export type WriteUnsafeDepositTransactionParameters<
-  TAbi extends Abi | readonly unknown[] = typeof optimismPortalABI,
-  TFunctionName extends string = 'depositTransaction',
   TChain extends Chain | undefined = Chain,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
 > = Omit<
   WriteContractParameters<
-    TAbi,
-    TFunctionName,
+    typeof optimismPortalABI,
+    'depositTransaction',
     TChain,
     TAccount,
     TChainOverride
@@ -44,8 +42,6 @@ export type WriteUnsafeDepositTransactionParameters<
 export async function writeUnsafeDepositTransaction<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  const TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string,
   TChainOverride extends Chain | undefined,
 >(
   client: WalletClient<Transport, TChain, TAccount>,
@@ -53,19 +49,19 @@ export async function writeUnsafeDepositTransaction<
     args: { to, value, gasLimit, isCreation, data },
     toChain,
     ...rest
-  }: WriteUnsafeDepositTransactionParameters<
-    TAbi,
-    TFunctionName,
-    TChain,
-    TAccount,
-    TChainOverride
-  >,
+  }: WriteUnsafeDepositTransactionParameters<TChain, TAccount, TChainOverride>,
 ): Promise<WriteContractReturnType> {
   return writeContract(client, {
     address: toChain.opContracts.OptimismPortalProxy,
     abi: optimismPortalABI,
-    functionName: 'depositTransaction',
+    functionName: 'depositTransaction' as any,
     args: [to, value || 0n, gasLimit, isCreation || false, data || '0x'],
     ...rest,
-  } as any)
+  } as unknown as WriteContractParameters<
+    typeof optimismPortalABI,
+    'depositTransaction',
+    TChain,
+    TAccount,
+    TChainOverride
+  >)
 }

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -1,11 +1,10 @@
-import { Abi, Account, Chain, Transport, WriteContractReturnType } from 'viem'
+import { Account, Chain, Transport, WriteContractReturnType } from 'viem'
 import { WalletClient } from 'wagmi'
 import { bridgeWriteContract } from '../actions/wallet/bridgeWriteContract'
 import {
   WriteUnsafeDepositTransactionParameters,
   writeUnsafeDepositTransaction,
 } from '../actions/wallet/writeUnsafeDepositTransaction'
-import { optimismPortalABI } from '@eth-optimism/contracts-ts'
 
 /// NOTE We don't currently need account for exisiting actions but keeping in case
 // TODO need to add generics
@@ -18,13 +17,9 @@ export type WalletOpStackActions<
     args: Parameters<typeof bridgeWriteContract>[1],
   ) => Promise<string>
   writeUnsafeDepositTransaction: <
-    TAbi extends Abi | readonly unknown[] = typeof optimismPortalABI,
-    TFunctionName extends string = 'depositTransaction',
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: WriteUnsafeDepositTransactionParameters<
-      TAbi,
-      TFunctionName,
       TChain,
       TAccount,
       TChainOverride

--- a/src/utils/getDepositEventsInfoFromTxReceipt.ts
+++ b/src/utils/getDepositEventsInfoFromTxReceipt.ts
@@ -27,7 +27,10 @@ export function getDepositEventsInfoFromTxReceipt({
       data: l.data,
       topics: l.topics,
     })
-    if (l.logIndex && event.eventName === 'TransactionDeposited') {
+    if (event.eventName === 'TransactionDeposited') {
+      if (!l.logIndex) {
+        throw new Error('Found TransactionDeposited by logIndex undefined')
+      }
       depositEvents.push({ event, logIndex: l.logIndex })
     }
   }


### PR DESCRIPTION
There was an issue with the types for `writeUnsafeDepositTransaction` was not allowing `value` to be passed. I solved this by making the types less generic, which I think is good. 
```
WriteContractParameters<
    typeof optimismPortalABI,
    'depositTransaction',
    TChain,
    TAccount,
    TChainOverride
  >
```
Note: now value is required to be passed. We should think about how to distinguish the args.value from the top level value. The latter being the amount that will be minted on L2, the former being the mint that will be sent as msg.value in the call