### PR TITLE
simplify naming, and better ergonomics

### DIFF
--- a/src/actions/public/L1/getL2HashesForDepositTx.ts
+++ b/src/actions/public/L1/getL2HashesForDepositTx.ts
@@ -1,6 +1,6 @@
 import { Chain, Hash, type PublicClient, Transport } from 'viem'
-import { getDepositEventsInfoFromTxReceipt } from '../../../utils/getDepositEventsInfoFromTxReceipt'
 import { getL2HashFromL1DepositInfo } from '../../../utils/getL2HashFromL1DepositInfo'
+import { getTransactionDepositedEvents } from '../../../utils/getTransactionDepositedEvents'
 
 export type GetL2HashesForDepositTxParamters = {
   l1TxHash: Hash
@@ -18,14 +18,14 @@ export async function getL2HashesForDepositTx<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
   { l1TxHash }: GetL2HashesForDepositTxParamters,
 ): Promise<GetL2HashesForDepositTxReturnType> {
-  const receipt = await client.getTransactionReceipt({ hash: l1TxHash })
-  const depositEvents = getDepositEventsInfoFromTxReceipt({ receipt })
+  const txReceipt = await client.getTransactionReceipt({ hash: l1TxHash })
+  const depositEvents = getTransactionDepositedEvents({ txReceipt })
 
   return depositEvents.map(({ event, logIndex }) =>
     getL2HashFromL1DepositInfo({
       event,
       logIndex,
-      blockHash: receipt.blockHash,
+      blockHash: txReceipt.blockHash,
     })
   )
 }

--- a/src/utils/getDepositTransaction.ts
+++ b/src/utils/getDepositTransaction.ts
@@ -1,15 +1,29 @@
 import { Hex, size, slice } from 'viem'
-import { DepositTransaction, TransactionDepositedEvent } from '../types/depositTransaction'
+import { DepositTransaction, SourceHashDomain, TransactionDepositedEvent } from '../types/depositTransaction'
+import { getSourceHash } from './getSourceHash'
 
-export type GetDepositTransactionFromTransactionDepositedEventParams = {
-  event: TransactionDepositedEvent
-  sourceHash: Hex
-}
+export type getDepositTransactionParams =
+  & { event: TransactionDepositedEvent }
+  & ({
+    sourceHash: Hex
+    logIndex?: never
+    l1BlockHash?: never
+    domain?: never
+  } | {
+    sourceHash?: never
+    logIndex: number
+    l1BlockHash: Hex
+    domain?: SourceHashDomain
+  })
 
-export function getDepositTransactionFromTransactionDepositedEvent({
+export function getDepositTransaction({
   event,
   sourceHash,
-}: GetDepositTransactionFromTransactionDepositedEventParams): DepositTransaction {
+  logIndex,
+  l1BlockHash,
+  domain = SourceHashDomain.UserDeposit,
+}: getDepositTransactionParams): DepositTransaction {
+  sourceHash = sourceHash ?? getSourceHash({ domain, logIndex, l1BlockHash })
   /// code from https://github.com/ethereum-optimism/optimism/blob/develop/packages/core-utils/src/optimism/deposit-transaction.ts#L198
   /// with adaptions for viem
   const opaqueData = event.args.opaqueData

--- a/src/utils/getL2HashFromL1DepositInfo.ts
+++ b/src/utils/getL2HashFromL1DepositInfo.ts
@@ -1,7 +1,6 @@
 import { Hash, keccak256 } from 'viem'
-import { SourceHashDomain, TransactionDepositedEvent } from '../types/depositTransaction'
-import { getDepositTransactionFromTransactionDepositedEvent } from './getDepositTransactionFromTransactionDepositedEvent'
-import { getSourceHash } from './getSourceHash'
+import { TransactionDepositedEvent } from '../types/depositTransaction'
+import { getDepositTransaction } from './getDepositTransaction'
 import { rlpEncodeDepositTransaction } from './rlpEncodeDepositTransaction'
 
 type GetL2HashFromDepositInfoParams = {
@@ -15,17 +14,11 @@ export function getL2HashFromL1DepositInfo({
   logIndex,
   blockHash,
 }: GetL2HashFromDepositInfoParams) {
-  const sourceHash = getSourceHash({
-    domain: SourceHashDomain.UserDeposit,
+  const depositTx = getDepositTransaction({
+    event,
     logIndex,
     l1BlockHash: blockHash,
   })
-  const depositTx = getDepositTransactionFromTransactionDepositedEvent({
-    event,
-    sourceHash,
-  })
 
-  const rlp = rlpEncodeDepositTransaction(depositTx)
-
-  return keccak256(rlp)
+  return keccak256(rlpEncodeDepositTransaction(depositTx))
 }

--- a/src/utils/getTransactionDepositedEvents.test.ts
+++ b/src/utils/getTransactionDepositedEvents.test.ts
@@ -1,8 +1,8 @@
 import { TransactionReceipt } from 'viem'
 import { expect, test } from 'vitest'
-import { getDepositEventsInfoFromTxReceipt } from './getDepositEventsInfoFromTxReceipt'
+import { getTransactionDepositedEvents } from './getTransactionDepositedEvents'
 
-const receipt: TransactionReceipt = {
+const txReceipt: TransactionReceipt = {
   type: 'eip1559',
   transactionHash: '0xe94031c3174788c3fee7216465c50bb2b72e7a1963f5af807b3768da10827f5c',
   transactionIndex: 78,
@@ -39,8 +39,8 @@ const receipt: TransactionReceipt = {
 }
 
 test('returns correct event info', () => {
-  const events = getDepositEventsInfoFromTxReceipt({
-    receipt,
+  const events = getTransactionDepositedEvents({
+    txReceipt,
   })
 
   expect(events.length).toEqual(1)

--- a/src/utils/getTransactionDepositedEvents.ts
+++ b/src/utils/getTransactionDepositedEvents.ts
@@ -2,8 +2,13 @@ import { optimismPortalABI } from '@eth-optimism/contracts-ts'
 import { decodeEventLog, TransactionReceipt } from 'viem'
 import { TransactionDepositedEvent } from '../types/depositTransaction'
 
-type GetDepositEventInfoFromTxReceiptParams = {
-  receipt: TransactionReceipt
+type GetTransactionDepositedEventsParams = {
+  txReceipt: TransactionReceipt
+}
+
+type TransactionDepositedEventDetails = {
+  event: TransactionDepositedEvent
+  logIndex: number
 }
 
 /**
@@ -13,17 +18,14 @@ type GetDepositEventInfoFromTxReceiptParams = {
  * @param {TransactionReceipt} receipt the receipt of the transaction supposedly containing the TransactionDeposited event
  * @returns {GetDepositEventInfoFromTxReceiptParams} An array of L2 transaction hashes, corresponding to all TransactionDeposited events found in the transaction
  */
-export function getDepositEventsInfoFromTxReceipt({
-  receipt,
-}: GetDepositEventInfoFromTxReceiptParams): {
-  event: TransactionDepositedEvent
-  logIndex: number
-}[] {
+export function getTransactionDepositedEvents({
+  txReceipt,
+}: GetTransactionDepositedEventsParams): TransactionDepositedEventDetails[] {
   const depositEvents: {
     event: TransactionDepositedEvent
     logIndex: number
   }[] = []
-  for (const l of receipt.logs) {
+  for (const l of txReceipt.logs) {
     try {
       const event = decodeEventLog({
         abi: optimismPortalABI,


### PR DESCRIPTION
In this PR I 
- Rename 
  - getDepositEventInfoFromTxReceipt→ getTransactionDepositedEvents
  - getDepositTransactionFromTransactionDepositedEvent →  getDepositTransaction
- Allow source hash to not be passed to getDepositTransaction and compute as needed 