### PR TITLE
:sparkles: feat: Add gas estimation actions

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -36,6 +36,9 @@ export {
   type SimulateProveWithdrawalTransactionParameters,
   type SimulateProveWithdrawalTransactionReturnType,
 } from './public/L1/simulateProveWithdrawalTransaction.js'
+export { estimateFees, type EstimateFeesParameters } from './public/L2/estimateFees.js'
+export { estimateL1Fee, type EstimateL1FeeParameters } from './public/L2/estimateL1Fee.js'
+export { estimateL1GasUsed, type GasPriceOracleEstimator } from './public/L2/estimateL1GasUsed.js'
 export {
   getProveWithdrawalTransactionArgs,
   type GetProveWithdrawalTransactionArgsParams,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -38,7 +38,7 @@ export {
 } from './public/L1/simulateProveWithdrawalTransaction.js'
 export { estimateFees, type EstimateFeesParameters } from './public/L2/estimateFees.js'
 export { estimateL1Fee, type EstimateL1FeeParameters } from './public/L2/estimateL1Fee.js'
-export { estimateL1GasUsed, type GasPriceOracleEstimator } from './public/L2/estimateL1GasUsed.js'
+export { estimateL1GasUsed, type EstimateL1GasUsedParameters } from './public/L2/estimateL1GasUsed.js'
 export {
   getProveWithdrawalTransactionArgs,
   type GetProveWithdrawalTransactionArgsParams,

--- a/src/actions/public/L2/estimateFees.test.ts
+++ b/src/actions/public/L2/estimateFees.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The first 2 test cases are good documentation of how to use this library
+ */
+import { l2StandardBridgeABI, l2StandardBridgeAddress, optimistABI, optimistAddress } from '@eth-optimism/contracts-ts'
+import { createPublicClient, http, parseEther, parseGwei } from 'viem'
+import { optimism } from 'viem/chains'
+import { formatEther } from 'viem/utils'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { estimateFees } from './estimateFees.js'
+import { estimateL1Fee } from './estimateL1Fee.js'
+
+vi.mock('viem', async () => {
+  const _viem = (await vi.importActual('viem')) as any
+  return {
+    ..._viem,
+    // no way to get historical gas price
+    createPublicClient: (...args: [any]) => {
+      const client = _viem.createPublicClient(...args)
+      client.getGasPrice = async () => parseGwei('0.00000042')
+      return client
+    },
+  }
+})
+
+// using this optimist https://optimistic.etherscan.io/tx/0xaa291efba7ea40b0742e5ff84a1e7831a2eb6c2fc35001fa03ba80fd3b609dc9
+const blockNumber = BigInt(107028270)
+const optimistOwnerAddress = '0x77194aa25a06f932c10c0f25090f3046af2c85a6' as const
+const functionDataBurn = {
+  functionName: 'burn',
+  // this is an erc721 abi
+  abi: optimistABI,
+  args: [BigInt(optimistOwnerAddress)],
+  account: optimistOwnerAddress,
+  to: optimistAddress[10],
+  chainId: 10,
+} as const
+const functionDataBurnWithPriorityFees = {
+  ...functionDataBurn,
+  maxFeePerGas: parseGwei('2'),
+  maxPriorityFeePerGas: parseGwei('2'),
+} as const
+// This tx
+// https://optimistic.etherscan.io/tx/0xe6f3719be7327a991b9cb562ebf8d979cbca72bbdb2775f55a18274f4d0c9bbf
+const functionDataWithdraw = {
+  abi: l2StandardBridgeABI,
+  functionName: 'withdraw',
+  value: BigInt(parseEther('0.00000001')),
+  account: '0x6387a88a199120aD52Dd9742C7430847d3cB2CD4',
+  // currently a bug is making chain id 10 not exist
+  to: l2StandardBridgeAddress[420],
+  chainId: 10,
+  args: [
+    // l2 token address
+    '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
+    // amount
+    BigInt(parseEther('0.00000001')),
+    // l1 gas
+    0,
+    // extra data
+    '0x0',
+  ],
+  maxFeePerGas: parseGwei('.2'),
+  maxPriorityFeePerGas: parseGwei('.1'),
+} as const
+
+const viemClient = createPublicClient({
+  chain: optimism,
+  transport: http(process.env.VITE_L2_RPC_URL ?? 'https://mainnet.optimism.io'),
+})
+
+const paramsOptimist = {
+  blockNumber,
+} as const
+const paramsWithdraw = {
+  blockNumber: BigInt(107046472),
+} as const
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+test('estimateFees should return correct fees', async () => {
+  // burn
+  const res = await estimateFees(viemClient, { ...paramsOptimist, ...functionDataBurn })
+  expect(res).toMatchInlineSnapshot('20573203833264n')
+  expect(formatEther(res)).toMatchInlineSnapshot('"0.000020573203833264"')
+  expect(
+    await estimateFees(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('20573203833264n')
+  expect(
+    await estimateFees(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('20573203833264n')
+  expect(
+    await estimateFees(viemClient, {
+      ...paramsOptimist,
+      ...functionDataBurnWithPriorityFees,
+    }),
+  ).toMatchInlineSnapshot('21536992690265n')
+  // what is the l2 and l1 part of the fees for reference?
+  const l1Fee = await estimateL1Fee(viemClient, { ...paramsOptimist, ...functionDataBurn })
+  const l2Fee = res - l1Fee
+  expect(l1Fee).toMatchInlineSnapshot('20573185216764n')
+  expect(formatEther(l1Fee)).toMatchInlineSnapshot('"0.000020573185216764"')
+  expect(l2Fee).toMatchInlineSnapshot('18616500n')
+  expect(formatEther(l2Fee)).toMatchInlineSnapshot('"0.0000000000186165"')
+
+  // withdraw
+  const res2 = await estimateFees(viemClient, {
+    ...paramsWithdraw,
+    ...functionDataWithdraw,
+  })
+  expect(res2).toMatchInlineSnapshot('62857090247510n')
+  expect(
+    await estimateFees(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+  ).toMatchInlineSnapshot('62857090247510n')
+  expect(
+    await estimateFees(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+  ).toMatchInlineSnapshot('62857090247510n')
+  expect(
+    await estimateFees(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+  ).toMatchInlineSnapshot('62857090247510n')
+  expect(formatEther(res2)).toMatchInlineSnapshot('"0.00006285709024751"')
+  // what is the l2 and l1 part of the fees for reference?
+  const l1Fee2 = await estimateL1Fee(viemClient, {
+    ...paramsWithdraw,
+    ...functionDataWithdraw,
+  })
+  const l2Fee2 = res2 - l1Fee
+  expect(l1Fee2).toMatchInlineSnapshot('62857038894110n')
+  expect(formatEther(l1Fee2)).toMatchInlineSnapshot('"0.00006285703889411"')
+  expect(l2Fee2).toMatchInlineSnapshot('42283905030746n')
+  expect(formatEther(l2Fee2)).toMatchInlineSnapshot('"0.000042283905030746"')
+})

--- a/src/actions/public/L2/estimateFees.ts
+++ b/src/actions/public/L2/estimateFees.ts
@@ -1,0 +1,65 @@
+import {
+  type Abi,
+  encodeFunctionData,
+  type EncodeFunctionDataParameters,
+  type EstimateGasParameters,
+  type PublicClient,
+  type Transport,
+} from 'viem'
+import { type Chain } from 'viem/chains'
+import type { GasPriceOracleParameters, OracleTransactionParameters } from '../../../types/gasPriceOracle.js'
+import { estimateL1Fee } from './estimateL1Fee.js'
+
+export type EstimateFeesParameters<
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+> =
+  & OracleTransactionParameters<TAbi, TFunctionName>
+  & GasPriceOracleParameters
+  & Omit<EstimateGasParameters, 'data'>
+
+export type EstimateFees = <
+  TChain extends Chain | undefined,
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+>(
+  client: PublicClient<Transport, TChain>,
+  options: EstimateFeesParameters<TAbi, TFunctionName>,
+) => Promise<bigint>
+
+/**
+ * Estimates gas for an L2 transaction including the l1 fee
+ * on non OP chains this is usually GasUsed * GasPrice
+ * on OP chains this is GasUsed * GasPrice + L1Fee
+ * @example
+ * const feeValue = await estimateFees(publicClient, {
+ *   abi,
+ *   functionName: balanceOf,
+ *   args: [address],
+ * });
+ */
+export const estimateFees: EstimateFees = async (client, options) => {
+  const encodedFunctionData = encodeFunctionData({
+    abi: options.abi,
+    args: options.args,
+    functionName: options.functionName,
+  } as EncodeFunctionDataParameters)
+  const [l1Fee, l2Gas, l2GasPrice] = await Promise.all([
+    estimateL1Fee(client, {
+      ...options,
+      // account must be undefined or else viem will return undefined
+      account: undefined as any,
+    }),
+    client.estimateGas({
+      to: options.to,
+      account: options.account,
+      accessList: options.accessList,
+      blockNumber: options.blockNumber,
+      blockTag: options.blockTag,
+      data: encodedFunctionData,
+      value: options.value,
+    } as EstimateGasParameters<Chain>),
+    client.getGasPrice(),
+  ])
+  return l1Fee + l2Gas * l2GasPrice
+}

--- a/src/actions/public/L2/estimateL1Fee.test.ts
+++ b/src/actions/public/L2/estimateL1Fee.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The first 2 test cases are good documentation of how to use this library
+ */
+import { l2StandardBridgeABI, l2StandardBridgeAddress, optimistABI, optimistAddress } from '@eth-optimism/contracts-ts'
+import { createPublicClient, http, parseEther, parseGwei } from 'viem'
+import { optimism } from 'viem/chains'
+import { formatEther } from 'viem/utils'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { estimateL1Fee } from './estimateL1Fee.js'
+
+vi.mock('viem', async () => {
+  const _viem = (await vi.importActual('viem')) as any
+  return {
+    ..._viem,
+    // no way to get historical gas price
+    createPublicClient: (...args: [any]) => {
+      const client = _viem.createPublicClient(...args)
+      client.getGasPrice = async () => parseGwei('0.00000042')
+      return client
+    },
+  }
+})
+
+// using this optimist https://optimistic.etherscan.io/tx/0xaa291efba7ea40b0742e5ff84a1e7831a2eb6c2fc35001fa03ba80fd3b609dc9
+const blockNumber = BigInt(107028270)
+const optimistOwnerAddress = '0x77194aa25a06f932c10c0f25090f3046af2c85a6' as const
+const functionDataBurn = {
+  functionName: 'burn',
+  // this is an erc721 abi
+  abi: optimistABI,
+  args: [BigInt(optimistOwnerAddress)],
+  account: optimistOwnerAddress,
+  to: optimistAddress[10],
+  chainId: 10,
+} as const
+const functionDataBurnWithPriorityFees = {
+  ...functionDataBurn,
+  maxFeePerGas: parseGwei('2'),
+  maxPriorityFeePerGas: parseGwei('2'),
+} as const
+// This tx
+// https://optimistic.etherscan.io/tx/0xe6f3719be7327a991b9cb562ebf8d979cbca72bbdb2775f55a18274f4d0c9bbf
+const functionDataWithdraw = {
+  abi: l2StandardBridgeABI,
+  functionName: 'withdraw',
+  value: BigInt(parseEther('0.00000001')),
+  account: '0x6387a88a199120aD52Dd9742C7430847d3cB2CD4',
+  // currently a bug is making chain id 10 not exist
+  to: l2StandardBridgeAddress[420],
+  chainId: 10,
+  args: [
+    // l2 token address
+    '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
+    // amount
+    BigInt(parseEther('0.00000001')),
+    // l1 gas
+    0,
+    // extra data
+    '0x0',
+  ],
+  maxFeePerGas: parseGwei('.2'),
+  maxPriorityFeePerGas: parseGwei('.1'),
+} as const
+
+const viemClient = createPublicClient({
+  chain: optimism,
+  transport: http(process.env.VITE_L2_RPC_URL ?? 'https://mainnet.optimism.io'),
+})
+
+const paramsOptimist = {
+  blockNumber,
+} as const
+const paramsWithdraw = {
+  blockNumber: BigInt(107046472),
+} as const
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+test(estimateL1Fee.name, async () => {
+  // burn
+  expect(
+    await estimateL1Fee(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('20573185216764n')
+  expect(
+    await estimateL1Fee(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('20573185216764n')
+  expect(
+    await estimateL1Fee(viemClient, {
+      ...paramsOptimist,
+      ...functionDataBurnWithPriorityFees,
+    }),
+  ).toMatchInlineSnapshot('21536974073765n')
+  expect(
+    formatEther(
+      await estimateL1Fee(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+    ),
+  ).toMatchInlineSnapshot('"0.000020573185216764"')
+  // withdraw
+  expect(
+    await estimateL1Fee(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+  ).toMatchInlineSnapshot('62857038894110n')
+  expect(
+    formatEther(
+      await estimateL1Fee(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+    ),
+  ).toMatchInlineSnapshot('"0.00006285703889411"')
+})

--- a/src/actions/public/L2/estimateL1Fee.ts
+++ b/src/actions/public/L2/estimateL1Fee.ts
@@ -1,7 +1,6 @@
 import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
 import {
   type Abi,
-  type BlockTag,
   type EncodeFunctionDataParameters,
   type PublicClient,
   type TransactionSerializableEIP1559,
@@ -9,21 +8,8 @@ import {
 } from 'viem'
 import { readContract } from 'viem/actions'
 import { type Chain } from 'viem/chains'
+import type { BlockOptions } from '../../../types/gasPriceOracle.js'
 import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
-
-/**
- * Options to query a specific block
- */
-type BlockOptions = {
-  /**
-   * Block number to query from
-   */
-  blockNumber?: bigint
-  /**
-   * Block tag to query from
-   */
-  blockTag?: BlockTag
-}
 
 /**
  * Options for all GasPriceOracle methods

--- a/src/actions/public/L2/estimateL1Fee.ts
+++ b/src/actions/public/L2/estimateL1Fee.ts
@@ -1,0 +1,75 @@
+import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
+import {
+  type Abi,
+  type BlockTag,
+  type EncodeFunctionDataParameters,
+  type PublicClient,
+  type TransactionSerializableEIP1559,
+  type Transport,
+} from 'viem'
+import { readContract } from 'viem/actions'
+import { type Chain } from 'viem/chains'
+import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
+
+/**
+ * Options to query a specific block
+ */
+type BlockOptions = {
+  /**
+   * Block number to query from
+   */
+  blockNumber?: bigint
+  /**
+   * Block tag to query from
+   */
+  blockTag?: BlockTag
+}
+
+/**
+ * Options for all GasPriceOracle methods
+ */
+export type GasPriceOracleParameters = BlockOptions
+
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type OracleTransactionParameters<
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+> =
+  & EncodeFunctionDataParameters<TAbi, TFunctionName>
+  & Omit<TransactionSerializableEIP1559, 'data' | 'type'>
+  & GasPriceOracleParameters
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type GasPriceOracleEstimator = <
+  TChain extends Chain | undefined,
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+>(
+  client: PublicClient<Transport, TChain>,
+  options: OracleTransactionParameters<TAbi, TFunctionName>,
+) => Promise<bigint>
+
+/**
+ * Computes the L1 portion of the fee based on the size of the rlp encoded input
+ * transaction, the current L1 base fee, and the various dynamic parameters.
+ * @example
+ * const L1FeeValue = await estimateL1Fee(publicClient, {
+ *   abi,
+ *   functionName: balanceOf,
+ *   args: [address],
+ * });
+ */
+export const estimateL1Fee: GasPriceOracleEstimator = async (client, options) => {
+  const data = serializeEip1559Transaction(options)
+  return readContract(client, {
+    address: gasPriceOracleAddress['420'],
+    abi: gasPriceOracleABI,
+    blockNumber: options.blockNumber,
+    blockTag: options.blockTag,
+    args: [data],
+    functionName: 'getL1Fee',
+  })
+}

--- a/src/actions/public/L2/estimateL1Fee.ts
+++ b/src/actions/public/L2/estimateL1Fee.ts
@@ -1,31 +1,15 @@
 import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
-import {
-  type Abi,
-  type EncodeFunctionDataParameters,
-  type PublicClient,
-  type TransactionSerializableEIP1559,
-  type Transport,
-} from 'viem'
+import { type Abi, type PublicClient, type Transport } from 'viem'
 import { readContract } from 'viem/actions'
 import { type Chain } from 'viem/chains'
-import type { BlockOptions } from '../../../types/gasPriceOracle.js'
+import type { OracleTransactionParameters } from '../../../types/gasPriceOracle.js'
 import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
 
-/**
- * Options for all GasPriceOracle methods
- */
-export type GasPriceOracleParameters = BlockOptions
+export type EstimateL1FeeParameters<
+  TAbi extends Abi,
+  TFunctionName extends string | undefined,
+> = OracleTransactionParameters<TAbi, TFunctionName>
 
-/**
- * Options for specifying the transaction being estimated
- */
-export type OracleTransactionParameters<
-  TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string | undefined = undefined,
-> =
-  & EncodeFunctionDataParameters<TAbi, TFunctionName>
-  & Omit<TransactionSerializableEIP1559, 'data' | 'type'>
-  & GasPriceOracleParameters
 /**
  * Options for specifying the transaction being estimated
  */
@@ -48,7 +32,10 @@ export type GasPriceOracleEstimator = <
  *   args: [address],
  * });
  */
-export const estimateL1Fee: GasPriceOracleEstimator = async (client, options) => {
+export const estimateL1Fee: GasPriceOracleEstimator = async (
+  client,
+  options,
+) => {
   const data = serializeEip1559Transaction(options)
   return readContract(client, {
     address: gasPriceOracleAddress['420'],

--- a/src/actions/public/L2/estimateL1GasUsed.test.ts
+++ b/src/actions/public/L2/estimateL1GasUsed.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The first 2 test cases are good documentation of how to use this library
+ */
+import { l2StandardBridgeABI, l2StandardBridgeAddress, optimistABI, optimistAddress } from '@eth-optimism/contracts-ts'
+import { createPublicClient, http, parseEther, parseGwei } from 'viem'
+import { optimism } from 'viem/chains'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { estimateL1GasUsed } from './estimateL1GasUsed.js'
+
+vi.mock('viem', async () => {
+  const _viem = (await vi.importActual('viem')) as any
+  return {
+    ..._viem,
+    // no way to get historical gas price
+    createPublicClient: (...args: [any]) => {
+      const client = _viem.createPublicClient(...args)
+      client.getGasPrice = async () => parseGwei('0.00000042')
+      return client
+    },
+  }
+})
+
+// using this optimist https://optimistic.etherscan.io/tx/0xaa291efba7ea40b0742e5ff84a1e7831a2eb6c2fc35001fa03ba80fd3b609dc9
+const blockNumber = BigInt(107028270)
+const optimistOwnerAddress = '0x77194aa25a06f932c10c0f25090f3046af2c85a6' as const
+const functionDataBurn = {
+  functionName: 'burn',
+  // this is an erc721 abi
+  abi: optimistABI,
+  args: [BigInt(optimistOwnerAddress)],
+  account: optimistOwnerAddress,
+  to: optimistAddress[10],
+  chainId: 10,
+} as const
+const functionDataBurnWithPriorityFees = {
+  ...functionDataBurn,
+  maxFeePerGas: parseGwei('2'),
+  maxPriorityFeePerGas: parseGwei('2'),
+} as const
+// This tx
+// https://optimistic.etherscan.io/tx/0xe6f3719be7327a991b9cb562ebf8d979cbca72bbdb2775f55a18274f4d0c9bbf
+const functionDataWithdraw = {
+  abi: l2StandardBridgeABI,
+  functionName: 'withdraw',
+  value: BigInt(parseEther('0.00000001')),
+  account: '0x6387a88a199120aD52Dd9742C7430847d3cB2CD4',
+  // currently a bug is making chain id 10 not exist
+  to: l2StandardBridgeAddress[420],
+  chainId: 10,
+  args: [
+    // l2 token address
+    '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
+    // amount
+    BigInt(parseEther('0.00000001')),
+    // l1 gas
+    0,
+    // extra data
+    '0x0',
+  ],
+  maxFeePerGas: parseGwei('.2'),
+  maxPriorityFeePerGas: parseGwei('.1'),
+} as const
+
+const viemClient = createPublicClient({
+  chain: optimism,
+  transport: http(process.env.VITE_L2_RPC_URL ?? 'https://mainnet.optimism.io'),
+})
+
+const paramsOptimist = {
+  blockNumber,
+} as const
+const paramsWithdraw = {
+  blockNumber: BigInt(107046472),
+} as const
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+test('getL1GasUsed should return the correct result', async () => {
+  // burn
+  expect(
+    await estimateL1GasUsed(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('2220n')
+  expect(
+    await estimateL1GasUsed(viemClient, { ...paramsOptimist, ...functionDataBurn }),
+  ).toMatchInlineSnapshot('2220n')
+  expect(
+    await estimateL1GasUsed(viemClient, {
+      ...paramsOptimist,
+      ...functionDataBurnWithPriorityFees,
+    }),
+  ).toMatchInlineSnapshot('2324n')
+  // withdraw
+  expect(
+    await estimateL1GasUsed(viemClient, { ...paramsWithdraw, ...functionDataWithdraw }),
+  ).toMatchInlineSnapshot('2868n')
+})

--- a/src/actions/public/L2/estimateL1GasUsed.ts
+++ b/src/actions/public/L2/estimateL1GasUsed.ts
@@ -1,0 +1,74 @@
+import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
+import {
+  type Abi,
+  type BlockTag,
+  type EncodeFunctionDataParameters,
+  type PublicClient,
+  type TransactionSerializableEIP1559,
+  type Transport,
+} from 'viem'
+import { readContract } from 'viem/actions'
+import { type Chain } from 'viem/chains'
+import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
+
+/**
+ * Options to query a specific block
+ */
+type BlockOptions = {
+  /**
+   * Block number to query from
+   */
+  blockNumber?: bigint
+  /**
+   * Block tag to query from
+   */
+  blockTag?: BlockTag
+}
+
+/**
+ * Options for all GasPriceOracle methods
+ */
+export type GasPriceOracleParameters = BlockOptions
+
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type OracleTransactionParameters<
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+> =
+  & EncodeFunctionDataParameters<TAbi, TFunctionName>
+  & Omit<TransactionSerializableEIP1559, 'data' | 'type'>
+  & GasPriceOracleParameters
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type GasPriceOracleEstimator = <
+  TChain extends Chain | undefined,
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+>(
+  client: PublicClient<Transport, TChain>,
+  options: OracleTransactionParameters<TAbi, TFunctionName>,
+) => Promise<bigint>
+
+/**
+ * Returns the L1 gas used
+ * @example
+ * const L1GasUsedValue = await estimateL1GasUsed(data, {
+ *  abi,
+ *  functionName: balanceOf,
+ *  args: [address],
+ * });
+ */
+export const estimateL1GasUsed: GasPriceOracleEstimator = async (client, options) => {
+  const data = serializeEip1559Transaction(options)
+  return readContract(client, {
+    address: gasPriceOracleAddress['420'],
+    abi: gasPriceOracleABI,
+    blockNumber: options.blockNumber,
+    blockTag: options.blockTag,
+    functionName: 'getL1GasUsed',
+    args: [data],
+  })
+}

--- a/src/actions/public/L2/estimateL1GasUsed.ts
+++ b/src/actions/public/L2/estimateL1GasUsed.ts
@@ -1,32 +1,16 @@
 import { gasPriceOracleABI } from '@eth-optimism/contracts-ts'
-import {
-  type Abi,
-  type EncodeFunctionDataParameters,
-  type PublicClient,
-  type TransactionSerializableEIP1559,
-  type Transport,
-} from 'viem'
+import { type Abi, type PublicClient, type Transport } from 'viem'
 import { readContract } from 'viem/actions'
 import { type Chain } from 'viem/chains'
 import { opStackL2ChainContracts } from '../../../index.js'
-import type { BlockOptions } from '../../../types/gasPriceOracle.js'
+import type { OracleTransactionParameters } from '../../../types/gasPriceOracle.js'
 import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
 
-/**
- * Options for all GasPriceOracle methods
- */
-export type GasPriceOracleParameters = BlockOptions
+export type EstimateL1GasUsedParameters<
+  TAbi extends Abi,
+  TFunctionName extends string | undefined,
+> = OracleTransactionParameters<TAbi, TFunctionName>
 
-/**
- * Options for specifying the transaction being estimated
- */
-export type OracleTransactionParameters<
-  TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string | undefined = undefined,
-> =
-  & EncodeFunctionDataParameters<TAbi, TFunctionName>
-  & Omit<TransactionSerializableEIP1559, 'data' | 'type'>
-  & GasPriceOracleParameters
 /**
  * Options for specifying the transaction being estimated
  */

--- a/src/actions/public/L2/estimateL1GasUsed.ts
+++ b/src/actions/public/L2/estimateL1GasUsed.ts
@@ -1,7 +1,6 @@
 import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
 import {
   type Abi,
-  type BlockTag,
   type EncodeFunctionDataParameters,
   type PublicClient,
   type TransactionSerializableEIP1559,
@@ -9,21 +8,8 @@ import {
 } from 'viem'
 import { readContract } from 'viem/actions'
 import { type Chain } from 'viem/chains'
+import type { BlockOptions } from '../../../types/gasPriceOracle.js'
 import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
-
-/**
- * Options to query a specific block
- */
-type BlockOptions = {
-  /**
-   * Block number to query from
-   */
-  blockNumber?: bigint
-  /**
-   * Block tag to query from
-   */
-  blockTag?: BlockTag
-}
 
 /**
  * Options for all GasPriceOracle methods

--- a/src/actions/public/L2/estimateL1GasUsed.ts
+++ b/src/actions/public/L2/estimateL1GasUsed.ts
@@ -1,4 +1,4 @@
-import { gasPriceOracleABI, gasPriceOracleAddress } from '@eth-optimism/contracts-ts'
+import { gasPriceOracleABI } from '@eth-optimism/contracts-ts'
 import {
   type Abi,
   type EncodeFunctionDataParameters,
@@ -8,6 +8,7 @@ import {
 } from 'viem'
 import { readContract } from 'viem/actions'
 import { type Chain } from 'viem/chains'
+import { opStackL2ChainContracts } from '../../../index.js'
 import type { BlockOptions } from '../../../types/gasPriceOracle.js'
 import { serializeEip1559Transaction } from '../../../utils/transactionSerializer.js'
 
@@ -47,10 +48,13 @@ export type GasPriceOracleEstimator = <
  *  args: [address],
  * });
  */
-export const estimateL1GasUsed: GasPriceOracleEstimator = async (client, options) => {
+export const estimateL1GasUsed: GasPriceOracleEstimator = async (
+  client,
+  options,
+) => {
   const data = serializeEip1559Transaction(options)
   return readContract(client, {
-    address: gasPriceOracleAddress['420'],
+    address: opStackL2ChainContracts.gasPriceOracle.address,
     abi: gasPriceOracleABI,
     blockNumber: options.blockNumber,
     blockTag: options.blockTag,

--- a/src/decorators/publicL2OpStackActions.ts
+++ b/src/decorators/publicL2OpStackActions.ts
@@ -1,4 +1,7 @@
-import type { Chain, PublicClient, Transport } from 'viem'
+import type { Abi, Chain, PublicClient, Transport } from 'viem'
+import { estimateFees, type EstimateFeesParameters } from '../actions/public/L2/estimateFees.js'
+import { estimateL1Fee } from '../actions/public/L2/estimateL1Fee.js'
+import { estimateL1GasUsed } from '../actions/public/L2/estimateL1GasUsed.js'
 import {
   getProveWithdrawalTransactionArgs,
   type GetProveWithdrawalTransactionArgsParams,
@@ -9,6 +12,7 @@ import {
   type GetWithdrawalMessagesParameters,
   type GetWithdrawalMessagesReturnType,
 } from '../actions/public/L2/getWithdrawalMessages.js'
+import { type OracleTransactionParameters } from '../types/gasPriceOracle.js'
 
 export type PublicL2OpStackActions = {
   getWithdrawalMessages: (
@@ -17,6 +21,23 @@ export type PublicL2OpStackActions = {
   getProveWithdrawalTransactionArgs: (
     args: GetProveWithdrawalTransactionArgsParams,
   ) => Promise<GetProveWithdrawalTransactionArgsReturnType>
+  /**
+   * Estimate the l1 gas price portion for a transaction
+   * @example
+   * const price = await getL1GasPrice(publicClient, {
+   *   blockNumber,
+   *   blockTag,
+   * });
+   */
+  estimateL1Fee: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
+    args: OracleTransactionParameters<TAbi, TFunctionName>,
+  ) => Promise<bigint>
+  estimateL1GasUsed: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
+    args: OracleTransactionParameters<TAbi, TFunctionName>,
+  ) => Promise<bigint>
+  estimateFees: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
+    args: EstimateFeesParameters<TAbi, TFunctionName>,
+  ) => Promise<bigint>
 }
 
 export function publicL2OpStackActions<
@@ -28,5 +49,8 @@ export function publicL2OpStackActions<
   return {
     getWithdrawalMessages: (args) => getWithdrawalMessages(client, args),
     getProveWithdrawalTransactionArgs: (args) => getProveWithdrawalTransactionArgs(client, args),
+    estimateL1Fee: (args) => estimateL1Fee(client, args),
+    estimateL1GasUsed: (args) => estimateL1GasUsed(client, args),
+    estimateFees: (args) => estimateFees(client, args),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ export type { DepositERC20Parameters } from './types/depositERC20.js'
 export type { DepositETHParameters } from './types/depositETH.js'
 export type { DepositTransaction, TransactionDepositedEvent } from './types/depositTransaction.js'
 export { DEPOSIT_TX_PREFIX, SourceHashDomain } from './types/depositTransaction.js'
+export type {
+  BlockOptions,
+  GasPriceOracleEstimator,
+  GasPriceOracleParameters,
+  OracleTransactionParameters,
+} from './types/gasPriceOracle.js'
 export type { OpStackChain, OpStackConfig } from './types/opStackChain.js'
 export {
   OpStackL1Contract,

--- a/src/types/gasPriceOracle.ts
+++ b/src/types/gasPriceOracle.ts
@@ -11,7 +11,7 @@ import type { Chain } from 'viem/chains'
 /**
  * Options to query a specific block
  */
-type BlockOptions = {
+export type BlockOptions = {
   /**
    * Block number to query from
    */

--- a/src/types/gasPriceOracle.ts
+++ b/src/types/gasPriceOracle.ts
@@ -1,0 +1,50 @@
+import type {
+  Abi,
+  BlockTag,
+  EncodeFunctionDataParameters,
+  PublicClient,
+  TransactionSerializableEIP1559,
+  Transport,
+} from 'viem'
+import type { Chain } from 'viem/chains'
+
+/**
+ * Options to query a specific block
+ */
+type BlockOptions = {
+  /**
+   * Block number to query from
+   */
+  blockNumber?: bigint
+  /**
+   * Block tag to query from
+   */
+  blockTag?: BlockTag
+}
+
+/**
+ * Options for all GasPriceOracle methods
+ */
+export type GasPriceOracleParameters = BlockOptions
+
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type OracleTransactionParameters<
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+> =
+  & EncodeFunctionDataParameters<TAbi, TFunctionName>
+  & Omit<TransactionSerializableEIP1559, 'data' | 'type'>
+  & GasPriceOracleParameters
+/**
+ * Options for specifying the transaction being estimated
+ */
+export type GasPriceOracleEstimator = <
+  TChain extends Chain | undefined,
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+>(
+  client: PublicClient<Transport, TChain>,
+  options: OracleTransactionParameters<TAbi, TFunctionName>,
+) => Promise<bigint>

--- a/src/utils/transactionSerializer.ts
+++ b/src/utils/transactionSerializer.ts
@@ -1,0 +1,28 @@
+import {
+  type Abi,
+  encodeFunctionData,
+  type EncodeFunctionDataParameters,
+  serializeTransaction,
+  type TransactionSerializableEIP1559,
+  type TransactionSerializedEIP1559,
+} from 'viem'
+
+/**
+ * Serializes a transaction with EIP-1559
+ */
+export const serializeEip1559Transaction = <
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string | undefined = undefined,
+>(
+  options:
+    & EncodeFunctionDataParameters<TAbi, TFunctionName>
+    & Omit<TransactionSerializableEIP1559, 'data'>,
+): TransactionSerializedEIP1559 => {
+  const encodedFunctionData = encodeFunctionData(options)
+  const serializedTransaction = serializeTransaction({
+    ...options,
+    data: encodedFunctionData,
+    type: 'eip1559',
+  })
+  return serializedTransaction as TransactionSerializedEIP1559
+}


### PR DESCRIPTION
- Copy paste gas estimation actions from https://github.com/ethereum-optimism/optimism/blob/develop/packages/fee-estimation/src/estimateFees.spec.ts
- Changed naming conventions to match op-viem
- deleted some of the more niche actions like `version` and `l1BaseFee`. The recommended way to use this is to just use the gasPriceOracle contract or get stuff like l1BaseFee from l1 they just bloat the API including them here imo