### PR TITLE
allow getL2HashesForDepositTx to take tx receipt

### DIFF
--- a/src/actions/public/L1/getL2HashesForDepositTx.test.ts
+++ b/src/actions/public/L1/getL2HashesForDepositTx.test.ts
@@ -19,6 +19,21 @@ test('correctly retrieves L2 hash', async () => {
   )
 })
 
+test('correctly retrieves L2 hash when given receipt', async () => {
+  const l1TxReceipt = await publicClient.getTransactionReceipt({
+    hash: '0x33faeeee9c6d5e19edcdfc003f329c6652f05502ffbf3218d9093b92589a42c4',
+  })
+  const hashes = await getL2HashesForDepositTx(publicClient, {
+    l1TxReceipt,
+  })
+
+  expect(hashes.length).toEqual(1)
+
+  expect(hashes[0]).toEqual(
+    '0xed88afbd3f126180bd5488c2212cd033c51a6f9b1765249bdb738dcac1d0cb41',
+  )
+})
+
 test('matches @eth-optimism/core-utils', async () => {
   const hashes = await getL2HashesForDepositTx(publicClient, {
     l1TxHash: '0x33faeeee9c6d5e19edcdfc003f329c6652f05502ffbf3218d9093b92589a42c4',

--- a/src/actions/public/L1/getL2HashesForDepositTx.ts
+++ b/src/actions/public/L1/getL2HashesForDepositTx.ts
@@ -1,10 +1,11 @@
-import type { Chain, Hash, PublicClient, Transport } from 'viem'
+import type { Chain, Hash, PublicClient, TransactionReceipt, Transport } from 'viem'
 import { getL2HashFromL1DepositInfo } from '../../../utils/getL2HashFromL1DepositInfo.js'
 import { getTransactionDepositedEvents } from '../../../utils/getTransactionDepositedEvents.js'
 
 export type GetL2HashesForDepositTxParamters = {
   l1TxHash: Hash
-}
+  l1TxReceipt?: never
+} | { l1TxHash?: never; l1TxReceipt: TransactionReceipt }
 
 export type GetL2HashesForDepositTxReturnType = Hash[]
 
@@ -16,9 +17,9 @@ export type GetL2HashesForDepositTxReturnType = Hash[]
  */
 export async function getL2HashesForDepositTx<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
-  { l1TxHash }: GetL2HashesForDepositTxParamters,
+  { l1TxHash, l1TxReceipt }: GetL2HashesForDepositTxParamters,
 ): Promise<GetL2HashesForDepositTxReturnType> {
-  const txReceipt = await client.getTransactionReceipt({ hash: l1TxHash })
+  const txReceipt = l1TxReceipt ?? await client.getTransactionReceipt({ hash: l1TxHash })
   const depositEvents = getTransactionDepositedEvents({ txReceipt })
 
   return depositEvents.map(({ event, logIndex }) =>

--- a/src/actions/public/L2/getWithdrawalMessages.test.ts
+++ b/src/actions/public/L2/getWithdrawalMessages.test.ts
@@ -2,9 +2,27 @@ import { expect, test } from 'vitest'
 import { rollupPublicClient } from '../../../_test/utils.js'
 import { getWithdrawalMessages } from './getWithdrawalMessages.js'
 
-test('correctly retrieves L2 hash', async () => {
+test('correctly retrieves messages from hash', async () => {
   const messages = await getWithdrawalMessages(rollupPublicClient, {
     hash: '0x999bab960dbdf600c51371ae819957063337a50cec2eb8032412739defadabe7',
+  })
+  expect(messages.blockNumber).toEqual(2725977n)
+  expect(messages.messages.length).toEqual(1)
+  expect(messages.messages[0].nonce).toBeDefined()
+  expect(messages.messages[0].gasLimit).toBeDefined()
+  expect(messages.messages[0].data).toBeDefined()
+  expect(messages.messages[0].value).toBeDefined()
+  expect(messages.messages[0].sender).toBeDefined()
+  expect(messages.messages[0].target).toBeDefined()
+  expect(messages.messages[0].withdrawalHash).toBeDefined()
+})
+
+test('correctly retrieves messages from receipt', async () => {
+  const txReceipt = await rollupPublicClient.getTransactionReceipt({
+    hash: '0x999bab960dbdf600c51371ae819957063337a50cec2eb8032412739defadabe7',
+  })
+  const messages = await getWithdrawalMessages(rollupPublicClient, {
+    txReceipt,
   })
   expect(messages.blockNumber).toEqual(2725977n)
   expect(messages.messages.length).toEqual(1)

--- a/src/actions/public/L2/getWithdrawalMessages.ts
+++ b/src/actions/public/L2/getWithdrawalMessages.ts
@@ -1,10 +1,11 @@
 import { l2ToL1MessagePasserABI } from '@eth-optimism/contracts-ts'
-import { type Chain, decodeEventLog, type Hash, type PublicClient, type Transport } from 'viem'
+import { type Chain, decodeEventLog, type Hash, type PublicClient, type TransactionReceipt, type Transport } from 'viem'
 import type { MessagePassedEvent } from '../../../types/withdrawal.js'
 
 export type GetWithdrawalMessagesParameters = {
   hash: Hash
-}
+  txReceipt?: never
+} | { hash?: never; txReceipt: TransactionReceipt }
 
 export type GetWithdrawalMessagesReturnType = {
   messages: MessagePassedEvent[]
@@ -20,9 +21,9 @@ export type GetWithdrawalMessagesReturnType = {
  */
 export async function getWithdrawalMessages<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
-  { hash }: GetWithdrawalMessagesParameters,
+  { hash, txReceipt }: GetWithdrawalMessagesParameters,
 ): Promise<GetWithdrawalMessagesReturnType> {
-  const receipt = await client.getTransactionReceipt({ hash })
+  const receipt = txReceipt ?? await client.getTransactionReceipt({ hash })
   const messages: MessagePassedEvent[] = []
   for (const log of receipt.logs) {
     /// These transactions will contain events from several contracts


### PR DESCRIPTION
In testing, I came across an issue where this method erred that it could not find the tx
<img width="594" alt="CleanShot 2023-09-16 at 16 01 28@2x" src="https://github.com/base-org/op-viem/assets/6678357/842b13d5-c7aa-4866-8b2b-3ed92104d906">

I considered changing this to have like a wait param or something, but it seems simpler just to allow this function to also just take the receipt and then the waiting can be down out of band. 