### PR TITLE
📝 docs: add `read*` functions with cleanup

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -38,12 +38,20 @@ export default defineConfig({
                 link: '/docs/actions/public/L1/getOutputForL2Block',
               },
               {
+                text: 'getSecondsToFinalizable',
+                link: '/docs/actions/public/L1/getSecondsToFinalizable',
+              },
+              {
                 text: 'getSecondsToNextL2Output',
                 link: '/docs/actions/public/L1/getSecondsToNextL2Output',
               },
               {
-                text: 'getSecondsToFinalizable',
-                link: '/docs/actions/public/L1/getSecondsToFinalizable',
+                text: 'readFinalizedWithdrawals',
+                link: '/docs/actions/public/L1/readFinalizedWithdrawals',
+              },
+              {
+                text: 'readProvenWithdrawals',
+                link: '/docs/actions/public/L1/readProvenWithdrawals',
               },
               {
                 text: 'simulateDepositERC20',
@@ -54,12 +62,12 @@ export default defineConfig({
                 link: '/docs/actions/public/L1/simulateDepositETH',
               },
               {
-                text: 'simulateProveWithdrawalTransaction',
-                link: '/docs/actions/public/L1/simulateProveWithdrawalTransaction',
-              },
-              {
                 text: 'simulateFinalizeWithdrawalTransaction',
                 link: '/docs/actions/public/L1/simulateFinalizeWithdrawalTransaction',
+              },
+              {
+                text: 'simulateProveWithdrawalTransaction',
+                link: '/docs/actions/public/L1/simulateProveWithdrawalTransaction',
               },
             ],
           },
@@ -75,11 +83,11 @@ export default defineConfig({
                 link: '/docs/actions/public/L2/getWithdrawalMessages',
               },
               {
-                text: 'simulateWithdrawETH',
-                link: '/docs/actions/public/L2/simulateWithdrawETH',
+                text: 'simulateWithdrawERC20',
+                link: '/docs/actions/public/L2/simulateWithdrawERC20',
               },
               {
-                text: 'simulateWithdrawERC20',
+                text: 'simulateWithdrawETH',
                 link: '/docs/actions/public/L2/simulateWithdrawETH',
               },
             ],

--- a/site/docs/actions/public/L1/getL2HashesForDepositTx.md
+++ b/site/docs/actions/public/L1/getL2HashesForDepositTx.md
@@ -2,8 +2,6 @@
 
 Get the L2 transaction hashes for a given L1 deposit transaction.
 
-::: code-group
-
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -19,5 +17,3 @@ const L2Hashes = await publicClient.getL2HashesForDepositTx({
     '0xe94031c3174788c3fee7216465c50bb2b72e7a1963f5af807b3768da10827f5c',
 })
 ```
-
-:::

--- a/site/docs/actions/public/L1/getOutputForL2Block.md
+++ b/site/docs/actions/public/L1/getOutputForL2Block.md
@@ -2,8 +2,6 @@
 
 Calls to the L2OutputOracle contract on L1 to get the output for a given L2 block.
 
-::: code-group
-
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'
 import { base } from 'op-viem/chains'
@@ -20,5 +18,3 @@ await getOutputForL2Block(publicClient, {
   l2Chain: base,
 })
 ```
-
-:::

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -35,7 +35,7 @@ The L2 chain to deposit to.
 
 - **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
 
-The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
+The address of the `OptimismPortal` contract where the `readProvenWithdrawals` call will be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
 
 ### l2OutputOracleAddress (optional)
 

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -37,6 +37,12 @@ The L2 chain to deposit to.
 
 The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
 
+### l2OutputOracleAddress (optional)
+
+- **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
+
+The address of the L2OutputOracle contract. MUST be provied if [l2Chain](l2chain-optional) is not.
+
 ### withdrawalHash
 
 - **Type:** `Hex`

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -41,7 +41,7 @@ The address of the `OptimismPortal` contract where the `readProvenWithdrawals` c
 
 - **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
 
-The address of the L2OutputOracle contract. MUST be provied if [l2Chain](l2chain-optional) is not.
+The address of the L2OutputOracle contract where the `FINALIZATION_PERIOD_SECONDS` call will be made. MUST be provied if [l2Chain](l2chain-optional) is not.
 
 ### withdrawalHash
 

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -31,8 +31,14 @@ Returns a `number` representative of the seconds until withdrawal finalization.
 
 The L2 chain to deposit to.
 
+### optimismPortalAddress (optional)
+
+- **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
+
+The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
+
 ### withdrawalHash
 
-- **Type:** `0x{string}`
+- **Type:** `Hex`
 
 The hash of the withdrawal

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -9,14 +9,15 @@ import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
 
 const publicClient = createPublicClient({
-    account,
-    chain: mainnet,
-    transport: http(),
+  account,
+  chain: mainnet,
+  transport: http(),
 }).extend(publicL1Actions)
 
 const seconds = await getSecondsToFinalizable(publicClient, {
-    l2Chain: base,
-    withdrawalHash: '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
+  l2Chain: base,
+  withdrawalHash:
+    '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
 ```
 

--- a/site/docs/actions/public/L1/getSecondsToFinalizable.md
+++ b/site/docs/actions/public/L1/getSecondsToFinalizable.md
@@ -2,8 +2,6 @@
 
 Returns the number of seconds until a withdrawal is finalized for a given withdrawal hash. Will return 0 if seconds would be negative.
 
-::: code-group
-
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -21,15 +19,13 @@ const seconds = await getSecondsToFinalizable(publicClient, {
 })
 ```
 
-:::
-
 ## Return Value
 
 Returns a `number` representative of the seconds until withdrawal finalization.
 
 ## Parameters
 
-### l2chain
+### l2chain (optional)
 
 - **Type:** `OpStackChain`
 

--- a/site/docs/actions/public/L1/getSecondsToNextL2Output.md
+++ b/site/docs/actions/public/L1/getSecondsToNextL2Output.md
@@ -2,8 +2,6 @@
 
 Returns how long until the next L2 output, for a given chain, is posted on L1. This is useful when waiting to prove a withdrawal.
 
-::: code-group
-
 ```ts [example.ts]
 const l2Client = createPublicClient({
   chain: base,
@@ -21,8 +19,6 @@ const time = await l1Client.getSecondsToNextL2Output(, {
   l2Chain: base,
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/public/L1/getSecondsToNextL2Output.md
+++ b/site/docs/actions/public/L1/getSecondsToNextL2Output.md
@@ -2,7 +2,9 @@
 
 Returns how long until the next L2 output, for a given chain, is posted on L1. This is useful when waiting to prove a withdrawal.
 
-```ts
+::: code-group
+
+```ts [example.ts]
 const l2Client = createPublicClient({
   chain: base,
   transport: http(),
@@ -19,6 +21,8 @@ const time = await l1Client.getSecondsToNextL2Output(, {
   l2Chain: base,
 })
 ```
+
+:::
 
 ## Return Value
 

--- a/site/docs/actions/public/L1/readFinalizedWithdrawals.md
+++ b/site/docs/actions/public/L1/readFinalizedWithdrawals.md
@@ -2,8 +2,6 @@
 
 Returns a boolean for whether the withdrawal of a given withdrawl hash has been finalized.
 
-::: code-group
-
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -20,8 +18,6 @@ const finalizedWithdrawal = await readFinalizedWithdrawals(publicClient, {
     '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/public/L1/readFinalizedWithdrawals.md
+++ b/site/docs/actions/public/L1/readFinalizedWithdrawals.md
@@ -25,14 +25,20 @@ Returns a `boolean` for whether the withdrawal has been finalized.
 
 ## Parameters
 
-### l2chain
+### l2chain (optional)
 
 - **Type:** `OpStackChain`
 
 The L2 chain to deposit to.
 
+### optimismPortalAddress (optional)
+
+- **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
+
+The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
+
 ### withdrawalHash
 
-- **Type:** `0x{string}`
+- **Type:** `Hex`
 
 The hash of the withdrawal

--- a/site/docs/actions/public/L1/readFinalizedWithdrawals.md
+++ b/site/docs/actions/public/L1/readFinalizedWithdrawals.md
@@ -1,6 +1,6 @@
-# getSecondsToFinalizable
+# readFinalizedWithdrawals
 
-Returns the number of seconds until a withdrawal is finalized for a given withdrawal hash. Will return 0 if seconds would be negative.
+Returns a boolean for whether the withdrawal of a given withdrawl hash has been finalized.
 
 ::: code-group
 
@@ -14,7 +14,7 @@ const publicClient = createPublicClient({
     transport: http(),
 }).extend(publicL1Actions)
 
-const seconds = await getSecondsToFinalizable(publicClient, {
+const finalizedWithdrawal = await readFinalizedWithdrawals(publicClient, {
     l2Chain: base,
     withdrawalHash: '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
@@ -24,7 +24,7 @@ const seconds = await getSecondsToFinalizable(publicClient, {
 
 ## Return Value
 
-Returns a `number` representative of the seconds until withdrawal finalization.
+Returns a `boolean` for whether the withdrawal has been finalized.
 
 ## Parameters
 

--- a/site/docs/actions/public/L1/readFinalizedWithdrawals.md
+++ b/site/docs/actions/public/L1/readFinalizedWithdrawals.md
@@ -9,14 +9,15 @@ import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
 
 const publicClient = createPublicClient({
-    account,
-    chain: mainnet,
-    transport: http(),
+  account,
+  chain: mainnet,
+  transport: http(),
 }).extend(publicL1Actions)
 
 const finalizedWithdrawal = await readFinalizedWithdrawals(publicClient, {
-    l2Chain: base,
-    withdrawalHash: '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
+  l2Chain: base,
+  withdrawalHash:
+    '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
 ```
 

--- a/site/docs/actions/public/L1/readProvenWithdrawals.md
+++ b/site/docs/actions/public/L1/readProvenWithdrawals.md
@@ -1,6 +1,6 @@
-# getSecondsToFinalizable
+# readProvenWithdrawals
 
-Returns the number of seconds until a withdrawal is finalized for a given withdrawal hash. Will return 0 if seconds would be negative.
+Returns a `ProvenWithdrawal` struct containing the `outputRoot`, `timestamp`, and `l2OutputIndex` for a given withdrawal hash. Returns error if withdrawal has not been proven.
 
 ::: code-group
 
@@ -14,7 +14,7 @@ const publicClient = createPublicClient({
     transport: http(),
 }).extend(publicL1Actions)
 
-const seconds = await getSecondsToFinalizable(publicClient, {
+const provenWithdrawal = await readProvenWithdrawals(publicClient, {
     l2Chain: base,
     withdrawalHash: '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
@@ -24,7 +24,7 @@ const seconds = await getSecondsToFinalizable(publicClient, {
 
 ## Return Value
 
-Returns a `number` representative of the seconds until withdrawal finalization.
+Returns an object that represents a `ProvenWithdrawl` struct that contains the `outputRoot`, `timestamp`, and `l2OutputIndex`
 
 ## Parameters
 

--- a/site/docs/actions/public/L1/readProvenWithdrawals.md
+++ b/site/docs/actions/public/L1/readProvenWithdrawals.md
@@ -9,14 +9,15 @@ import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
 
 const publicClient = createPublicClient({
-    account,
-    chain: mainnet,
-    transport: http(),
+  account,
+  chain: mainnet,
+  transport: http(),
 }).extend(publicL1Actions)
 
 const provenWithdrawal = await readProvenWithdrawals(publicClient, {
-    l2Chain: base,
-    withdrawalHash: '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
+  l2Chain: base,
+  withdrawalHash:
+    '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
 ```
 

--- a/site/docs/actions/public/L1/readProvenWithdrawals.md
+++ b/site/docs/actions/public/L1/readProvenWithdrawals.md
@@ -29,14 +29,20 @@ Returns an object that represents a `ProvenWithdrawl` struct that contains the `
 
 ## Parameters
 
-### l2chain
+### l2chain (optional)
 
 - **Type:** `OpStackChain`
+
+### optimismPortalAddress (optional)
+
+- **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
+
+The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
 
 The L2 chain to deposit to.
 
 ### withdrawalHash
 
-- **Type:** `0x{string}`
+- **Type:** `Hex`
 
 The hash of the withdrawal

--- a/site/docs/actions/public/L1/readProvenWithdrawals.md
+++ b/site/docs/actions/public/L1/readProvenWithdrawals.md
@@ -2,8 +2,6 @@
 
 Returns a `ProvenWithdrawal` struct containing the `outputRoot`, `timestamp`, and `l2OutputIndex` for a given withdrawal hash. Returns error if withdrawal has not been proven.
 
-::: code-group
-
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -20,8 +18,6 @@ const provenWithdrawal = await readProvenWithdrawals(publicClient, {
     '0xEC0AD491512F4EDC603C2DD7B9371A0B18D4889A23E74692101BA4C6DC9B5709',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/public/L1/simulateDepositERC20.md
+++ b/site/docs/actions/public/L1/simulateDepositERC20.md
@@ -2,8 +2,6 @@
 
 Simulates a deposit of ERC20 tokens to L2.
 
-::: code-group
-
 ```ts [example.ts]
 import { base, publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -29,8 +27,6 @@ const { request } = await publicClient.simulateDepositERC20({
   account: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/public/L1/simulateDepositETH.md
+++ b/site/docs/actions/public/L1/simulateDepositETH.md
@@ -2,8 +2,6 @@
 
 Simulates a deposit of ETH from L1 to L2.
 
-::: code-group
-
 ```ts [example.ts]
 import { base, publicL1Actions } from 'op-viem'
 import { createPublicClient } from 'viem'
@@ -24,8 +22,6 @@ const { request } = await publicClient.simulateDepositETH({
   account: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/wallet/L1/writeDepositERC20.md
+++ b/site/docs/actions/wallet/L1/writeDepositERC20.md
@@ -2,8 +2,6 @@
 
 Writes a deposit of ERC20 tokens from L1 to L2.
 
-::: code-group
-
 ```ts [example.ts]
 import { base, walletL1OpStackActions } from 'op-viem'
 import { createWalletClient } from 'viem'
@@ -28,8 +26,6 @@ const { request } = await walletClient.writeDepositERC20({
   account: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/actions/wallet/L1/writeDepositETH.md
+++ b/site/docs/actions/wallet/L1/writeDepositETH.md
@@ -2,8 +2,6 @@
 
 Writes a deposit of ETH from L1 to L2.
 
-::: code-group
-
 ```ts [example.ts]
 import { base, walletL1OpStackActions } from 'op-viem'
 import { createWalletClient } from 'viem'
@@ -23,8 +21,6 @@ const hash = await walletClient.writeDepositETH({
   account: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
 })
 ```
-
-:::
 
 ## Return Value
 

--- a/site/docs/utilities/deposits/getL2HashFromL1DepositInfo.md
+++ b/site/docs/utilities/deposits/getL2HashFromL1DepositInfo.md
@@ -2,8 +2,6 @@
 
 Get the L2 transaction hash for a given L1 deposit transaction.
 
-::: code-group
-
 ```ts [example.ts]
 import { getL2HashFromL1DepositInfo, TransactionDepositedEvent } from 'op-viem'
 
@@ -28,8 +26,6 @@ const hash = getL2HashFromL1DepositInfo({
   l1BlockHash: blockHash,
 })
 ```
-
-:::
 
 ## Returns
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,6 +15,7 @@ export {
   getSecondsToNextL2Output,
   type GetSecondsToNextL2OutputParameters,
 } from './public/L1/getSecondsToNextL2Output.js'
+export { readFinalizedWithdrawals, type ReadFinalizedWithdrawalsParameters } from './public/L1/readFinalizedWithdrawals.js'
 export { readProvenWithdrawals, type ReadProvenWithdrawalsParameters } from './public/L1/readProvenWithdrawals.js'
 export {
   simulateDepositERC20,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,7 +15,10 @@ export {
   getSecondsToNextL2Output,
   type GetSecondsToNextL2OutputParameters,
 } from './public/L1/getSecondsToNextL2Output.js'
-export { readFinalizedWithdrawals, type ReadFinalizedWithdrawalsParameters } from './public/L1/readFinalizedWithdrawals.js'
+export {
+  readFinalizedWithdrawals,
+  type ReadFinalizedWithdrawalsParameters,
+} from './public/L1/readFinalizedWithdrawals.js'
 export { readProvenWithdrawals, type ReadProvenWithdrawalsParameters } from './public/L1/readProvenWithdrawals.js'
 export {
   simulateDepositERC20,


### PR DESCRIPTION
The following actions have been added to the docs:

* `getSecondsToFinalizable`
* `readFinalizedWithdrawals`
* `readProvenWithdrawals`

Along with some other minor cleanup.

Resolves #82 