### PR TITLE
:art: feat: Demo the suggested API

### DIFF
--- a/src/actions/wallet/L1/writeDepositETH.ts
+++ b/src/actions/wallet/L1/writeDepositETH.ts
@@ -1,23 +1,47 @@
-import type { Account, Chain, Transport, WalletClient, WriteContractReturnType } from 'viem'
-import { ABI, CONTRACT, type DepositETHParameters, FUNCTION } from '../../../types/depositETH.js'
-import type { L1WriteActionBaseType } from '../../../types/l1Actions.js'
-import { writeOpStackL1, type WriteOpStackL1Parameters } from './writeOpStackL1.js'
+import { l1StandardBridgeABI } from '@eth-optimism/contracts-ts'
+import type {
+  Account,
+  Address,
+  Chain,
+  SendTransactionParameters,
+  Transport,
+  WalletClient,
+  WriteContractParameters,
+  WriteContractReturnType,
+} from 'viem'
+import { writeContract } from 'viem/actions'
+import { optimism, type mainnet } from 'viem/chains'
+import type { OpStackConfig } from '../../../index.js'
+import { ChainMismatchError } from 'wagmi'
 
+/**
+ * This wouldn't be in this file but just showing we can reexport contracts from @eth-optimism/contracts-ts
+ * This is a wagmi/core contract now but we can change it to viem
+ */
+export { getL1CrossDomainMessenger } from '@eth-optimism/contracts-ts/actions'
+
+// This type is less abstracted but in general I would recomend not abstracting and keeping it very simple
+// This API is very very likely to change (currently in alpha) and might radically change when it moves to viem
+// Keeping the types simple even if less DRY makes this easier to manage
 export type WriteDepositETHParameters<
   TChain extends Chain | undefined = Chain,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
 > =
-  & { args: DepositETHParameters }
-  & L1WriteActionBaseType<
+  // here we  are extending SendTransactionParameters because it's the closest viem action to what we are doing (sending eth)
+  // to make api intuitive use same api as sendTransaction. This makes it so we don't have to omit any properties
+  SendTransactionParameters<
     TChain,
     TAccount,
-    TChainOverride,
-    typeof ABI,
-    typeof CONTRACT,
-    typeof FUNCTION
-  >
-
+    TChainOverride
+  > & {
+    l1StandardBridge: Address
+    value: bigint
+    /**
+     * Provide really good jsdoc on what this is
+     */
+    minGasLimit: bigint
+  }
 /**
  * Deposits ETH to L2 using the standard messenger contract
  * @param parameters - {@link WriteDepositETHParameters}
@@ -30,8 +54,10 @@ export async function writeDepositETH<
 >(
   client: WalletClient<Transport, TChain, TAccount>,
   {
-    args: { to, minGasLimit, extraData = '0x' },
-    l1StandardBridgeAddress,
+    to,
+    minGasLimit,
+    data = '0x',
+    l1StandardBridge,
     ...rest
   }: WriteDepositETHParameters<
     TChain,
@@ -39,18 +65,130 @@ export async function writeDepositETH<
     TChainOverride
   >,
 ): Promise<WriteContractReturnType> {
-  return writeOpStackL1(client, {
-    address: l1StandardBridgeAddress,
-    abi: ABI,
-    contract: CONTRACT,
-    functionName: FUNCTION,
-    args: [to, minGasLimit, extraData],
+  // warn if this is way too low
+  const SOME_REASONABLE_MINIMUM = 420n
+  if (minGasLimit < SOME_REASONABLE_MINIMUM) {
+    console.warn('minGasLimit is very low. This might fail. Consider increasing it')
+  }
+
+  if (to) {
+    return writeContract(client, {
+      address: l1StandardBridge,
+      abi: l1StandardBridgeABI,
+      functionName: 'depositETHTo',
+      args: [to, minGasLimit, data],
+      ...rest,
+    } as unknown as WriteContractParameters<
+      typeof l1StandardBridgeABI,
+      'depositETH',
+      TChain,
+      TAccount,
+      TChainOverride
+    >)
+  }
+
+  return writeContract(client, {
+    address: l1StandardBridge,
+    abi: l1StandardBridgeABI,
+    functionName: 'depositETH',
+    args: [minGasLimit, data],
     ...rest,
-  } as unknown as WriteOpStackL1Parameters<
+  } as unknown as WriteContractParameters<
+    typeof l1StandardBridgeABI,
+    'depositETH',
     TChain,
     TAccount,
-    TChainOverride,
-    typeof ABI,
-    typeof FUNCTION
+    TChainOverride
   >)
+}
+
+// Instead of putting the config on the chain we put the chain on the config
+// this is significantly less invasive to viem
+const optimismConfig = {
+  ...(await import('../../../chains/optimism.js')).optimism.opStackConfig,
+  chain: optimism,
+}
+/**
+ * Most users will be using the client not the action. Actions in viem tend to be used mostly by those trying to squeeze out bundle size wins We can keep the actions simpler while still providing a streamlined experience for users using the client
+ */
+export const actionUsageExample = async () => {
+  // import {optimismConfig} from 'viem/optimism' ---- This import is reexported from the superchain registry package so no maintence is needed as more op chains are added except updating package
+
+  const client: WalletClient<any, typeof mainnet, Account> = {} as any
+
+  writeDepositETH(
+    client,
+    {
+      l1StandardBridge: optimismConfig.l1.contracts.l1StandardBridge.address,
+      minGasLimit: 420n,
+      value: 420n,
+    },
+  )
+}
+
+// As a general convention extensions/plugins tend to be factories so they can be configured
+// Our extension can get the same devx as previous API by taking in a config
+// This keeps the copmlexity of the op chains completely out of viem/chains and viem proper
+// Note we are only supporting 1 op chain here just like how a viem client only supports 1 l1 chain
+// This is great for these reasons:
+// 1. User can make multiple clients if they are using multiple chains. This totally fine and IMO actually cleaner than passing l2ChainId every usage
+// 2. Most users will have a single op chain. For them they get a simpler hook with less boilerplate
+// 3. They can still override the address if they choose to
+export const opViemExtension = <TConfig extends OpStackConfig>(config: TConfig) => {
+  return <
+    TTransport extends Transport = Transport,
+    TAccount extends Account = Account,
+    // gonna typecheck the l2 chains and l1 chains match here
+    TL1ChainId = TConfig['l1']['chainId'],
+    TChain extends Chain & { id: TL1ChainId } = Chain & { id: TL1ChainId },
+  > // this type could be even stricter but gonna keep it simple so it's easier to follow
+    (client: WalletClient<TTransport, TChain, TAccount>) => {
+    if (client.chain.id !== config.l1.chainId) {
+      throw new ChainMismatchError({
+        activeChain: client.chain.name,
+        targetChain: (config as any).chain.name
+      })
+    }
+    // here we can provide that good ux of not needing to provide contract addresses. User simply needs to configure them once in their entire app
+    // This is in line with how with viem clients you only need to configure rpc providers, multicall chain, chain objects etc. once
+    return {
+      // we are not going to allow users to override the chainId because they should just configure it up front
+      writeDepositETH: (
+        args:
+          & Omit<
+            WriteDepositETHParameters<
+              TChain,
+              TAccount,
+              TChain
+            >,
+            'l1StandardBridge'
+          >
+          & {
+            l1StandardBridge?: Address
+          },
+      ) => {
+        return writeDepositETH(client, {
+          l1StandardBridge: config.l1.contracts.l1StandardBridge.address,
+          ...args,
+        } as any)
+      },
+    }
+  }
+}
+
+export const opViemExtensionUsageExample = async () => {
+  // import {opViemExtension} from 'viem/optimism' ---- This import is reexported from the superchain registry package so no maintence is needed as more op chains are added except updating package
+
+  const client: WalletClient<any, typeof mainnet, Account> = {} as any
+
+  const opClient = client.extend(
+    opViemExtension(optimismConfig),
+  )
+
+  // don't need to provide contract address nor chain id because it was configured in the constructor
+  opClient.writeDepositETH({
+    // passing in minGasLimit sucks so we should encourage folks to use the prepare hooks
+    minGasLimit: 420n,
+    value: 420n,
+  })
 }


### PR DESCRIPTION
Demo what I think should be the final op-viem api. Overall this API is better in following ways

- Simpler API
- Can be added to viem without any internal changes to viem
- Way simpler types and implementation
- Less nuances in how the library behaves when given different options
- Less boilerplate needed by users to use the libary

### Actions take the contract address

The API is massively overcomplicated from taking an l2ChainId. Because we offer multiple ways to infer things or override things the behavior is extremely complicated and we are reliant on complicated typescript types along wtih runtime validation. Taking the contract address is way simpler.

This eliminates the requirement of putting all OP config on chain objects. Instead we export `optimismConfig` as a seperate object from the `optimism` chain object

### Config provided on client creation

The previous point eliminates the biggest benifit which is no longer being able to infer contracts from the rollup chain and not needing to reference contract address names (such as portal). We can have our cake and eat it too via providing config on client creation. `opViemExtension` in this api takes the config on initialization.

### 1 rollup per client

We can do both the first 2 things without this change. Alternative solution is to take an array of rollup configs instead of a single one.  Instead we expect user to create a seperate rollup client for every rollup bridge they are supporting.

```typescript
import * as opConfigs from 'viem/optimism'
const client = ...
const opClients = {
  10: client.extend(opConfigs.optimismConfig),
  420: client.extend(opConfigs.optimismGoerliConfig),
}
```
This would be my personal preference as a user of the library. 

I made it so the user can still override the standard bridge contract address should they choose to. It might be better to not even offer this option. One could argue we shouldn't offer this part of the API but I am unopinionated myself.

