### PR TITLE
:memo: docs: organize config.mts

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -81,7 +81,7 @@ export default defineConfig({
               },
               {
                 text: 'simulateWithdrawERC20',
-                link: '/docs/actions/public/L2/simulateWithdrawETH',
+                link: '/docs/actions/public/L2/simulateWithdrawERC20',
               },
             ],
           },
@@ -102,26 +102,34 @@ export default defineConfig({
                 link: '/docs/actions/wallet/L1/writeDepositETH',
               },
               {
-                text: 'writeUnsafeDepositTransaction',
-                link: '/docs/actions/wallet/L1/writeUnsafeDepositTransaction',
+                text: 'writeFinalizeWithdrawalTransaction',
+                link: '/docs/actions/wallet/L1/writeFinalizeWithdrawalTransaction',
               },
               {
-                text: 'writeSendMessage',
-                link: '/docs/actions/wallet/L1/writeSendMessage',
+                text: 'writeOpStackL1',
+                link: '/docs/actions/wallet/L1/writeOpStackL1',
               },
               {
                 text: 'writeProveWithdrawalTransaction',
                 link: '/docs/actions/wallet/L1/writeProveWithdrawalTransaction',
               },
               {
-                text: 'writeFinalizeWithdrawalTransaction',
-                link: '/docs/actions/wallet/L1/writeFinalizeWithdrawalTransaction',
+                text: 'writeSendMessage',
+                link: '/docs/actions/wallet/L1/writeSendMessage',
+              },
+              {
+                text: 'writeUnsafeDepositTransaction',
+                link: '/docs/actions/wallet/L1/writeUnsafeDepositTransaction',
               },
             ],
           },
           {
             text: 'L2',
             items: [
+              {
+                text: 'writeOpStackL2',
+                link: '/docs/actions/wallet/L2/writeOpStackL2',
+              },
               {
                 text: 'writeWithdrawETH',
                 link: '/docs/actions/wallet/L2/writeWithdrawETH',
@@ -168,6 +176,15 @@ export default defineConfig({
               {
                 text: 'getWithdrawlMessageStorageSlot',
                 link: '/docs/utilities/withdrawals/getWithdrawlMessageStorageSlot',
+              },
+            ],
+          },
+          {
+            text: 'General',
+            items: [
+              {
+                text: 'resolveL1OpStackContractAddress',
+                link: '/docs/utilities/general/resolveL1OpStackContractAddress',
               },
             ],
           },

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -179,15 +179,6 @@ export default defineConfig({
               },
             ],
           },
-          {
-            text: 'General',
-            items: [
-              {
-                text: 'resolveL1OpStackContractAddress',
-                link: '/docs/utilities/general/resolveL1OpStackContractAddress',
-              },
-            ],
-          },
         ],
       },
       {


### PR DESCRIPTION
* Organizes the actions in alphabetical order ([viem.sh](https://viem.sh/docs/getting-started.html) also uses alphabetical ordering of actions) 
* Creates and adds missing pages to index (will implement those once this is merged; plenty of empty pages already exist)
* Fixes a typo in the sidebar for `simulateWithdrawERC20`

Let me know if we prefer another name to the `General` category under `Utilities` for functions like `resolveL1OpStackContractAddress`.

