### PR TITLE
:white_check_mark: chore: add `resolveL1OpStackContractAddress` test

### DIFF
--- a/src/utils/resolveL1OpStackContractAddress.test.ts
+++ b/src/utils/resolveL1OpStackContractAddress.test.ts
@@ -17,6 +17,19 @@ test('resolves Base OptimismPortal contract address', async () => {
   expect(resolvedPortalAddress).toEqual('0x49048044D57e1C92A77f79988d21Fa8fAF74E97e')
 })
 
+test('returns address if provided', async () => {
+  const resolvedAddress = resolveL1OpStackContractAddress(
+    {
+      l2Chain: undefined,
+      chain: publicClient.chain,
+      contract: OpStackL1Contract.OptimismPortal,
+      address: '0x0000000000000000000000000000000000000001',
+    },
+  )
+
+  expect(resolvedAddress).toEqual('0x0000000000000000000000000000000000000001')
+})
+
 test('raises error if chain undefined', async () => {
   await expect(async () =>
     resolveL1OpStackContractAddress(

--- a/src/utils/resolveL1OpStackContractAddress.test.ts
+++ b/src/utils/resolveL1OpStackContractAddress.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+import { publicClient } from '../_test/utils.js'
+import { base } from '../chains/base.js'
+import { OpStackL1Contract } from '../types/opStackContracts.js'
+import { resolveL1OpStackContractAddress } from './resolveL1OpStackContractAddress.js'
+
+test('resolves Base OptimismPortal contract address', async () => {
+  const resolvedPortalAddress = await resolveL1OpStackContractAddress(
+    {
+      l2Chain: base,
+      chain: publicClient.chain,
+      contract: OpStackL1Contract.OptimismPortal,
+    },
+  )
+
+  expect(resolvedPortalAddress).toEqual('0x49048044D57e1C92A77f79988d21Fa8fAF74E97e')
+})
+
+test('raises error if chain undefined', async () => {
+  await expect(async () =>
+    resolveL1OpStackContractAddress(
+      {
+        l2Chain: undefined,
+        chain: publicClient.chain,
+        contract: OpStackL1Contract.OptimismPortal,
+      },
+    )
+  ).rejects.toThrowError('Must provide either l2Chain or optimismPortalAddress')
+})
+
+test('raises error if L1 mismatch', async () => {
+  publicClient.chain.id = 0
+
+  await expect(async () =>
+    resolveL1OpStackContractAddress(
+      {
+        l2Chain: base,
+        chain: publicClient.chain,
+        contract: OpStackL1Contract.OptimismPortal,
+      },
+    )
+  ).rejects.toThrowError('Chain ID "0" does not match expected L1 chain ID "1"')
+})

--- a/src/utils/resolveL1OpStackContractAddress.test.ts
+++ b/src/utils/resolveL1OpStackContractAddress.test.ts
@@ -1,3 +1,4 @@
+import type { Chain } from 'viem'
 import { expect, test } from 'vitest'
 import { publicClient } from '../_test/utils.js'
 import { base } from '../chains/base.js'
@@ -17,27 +18,29 @@ test('resolves Base OptimismPortal contract address', async () => {
 })
 
 test('raises error if chain undefined', async () => {
-  await expect(async () =>
-    resolveL1OpStackContractAddress(
-      {
-        l2Chain: undefined,
-        chain: publicClient.chain,
-        contract: OpStackL1Contract.OptimismPortal,
-      },
-    )
-  ).rejects.toThrowError('Must provide either l2Chain or optimismPortalAddress')
-})
-
+    await expect(async () =>
+      resolveL1OpStackContractAddress(
+        {
+          l2Chain: undefined,
+          chain: publicClient.chain,
+          contract: OpStackL1Contract.OptimismPortal,
+        }
+      )
+    ).rejects.toThrowError('Must provide either l2Chain or optimismPortalAddress');
+  });
+      
 test('raises error if L1 mismatch', async () => {
-  publicClient.chain.id = 0
-
-  await expect(async () =>
-    resolveL1OpStackContractAddress(
-      {
-        l2Chain: base,
-        chain: publicClient.chain,
-        contract: OpStackL1Contract.OptimismPortal,
-      },
-    )
-  ).rejects.toThrowError('Chain ID "0" does not match expected L1 chain ID "1"')
-})
+    // Create a mock of publicClient with the modified chain ID
+    const mockClient = { ...publicClient, chain: { id: 0 } as Chain };
+  
+    await expect(async () =>
+      resolveL1OpStackContractAddress(
+        {
+          l2Chain: base,
+          chain: mockClient.chain,
+          contract: OpStackL1Contract.OptimismPortal,
+        },
+      )
+    ).rejects.toThrowError('Chain ID "0" does not match expected L1 chain ID "1"');
+});
+    

--- a/src/utils/resolveL1OpStackContractAddress.test.ts
+++ b/src/utils/resolveL1OpStackContractAddress.test.ts
@@ -20,6 +20,7 @@ test('resolves Base OptimismPortal contract address', async () => {
 test('raises error if chain undefined', async () => {
   await expect(async () =>
     resolveL1OpStackContractAddress(
+      // @ts-expect-error
       {
         l2Chain: undefined,
         chain: publicClient.chain,

--- a/src/utils/resolveL1OpStackContractAddress.test.ts
+++ b/src/utils/resolveL1OpStackContractAddress.test.ts
@@ -18,29 +18,28 @@ test('resolves Base OptimismPortal contract address', async () => {
 })
 
 test('raises error if chain undefined', async () => {
-    await expect(async () =>
-      resolveL1OpStackContractAddress(
-        {
-          l2Chain: undefined,
-          chain: publicClient.chain,
-          contract: OpStackL1Contract.OptimismPortal,
-        }
-      )
-    ).rejects.toThrowError('Must provide either l2Chain or optimismPortalAddress');
-  });
-      
+  await expect(async () =>
+    resolveL1OpStackContractAddress(
+      {
+        l2Chain: undefined,
+        chain: publicClient.chain,
+        contract: OpStackL1Contract.OptimismPortal,
+      },
+    )
+  ).rejects.toThrowError('Must provide either l2Chain or optimismPortalAddress')
+})
+
 test('raises error if L1 mismatch', async () => {
-    // Create a mock of publicClient with the modified chain ID
-    const mockClient = { ...publicClient, chain: { id: 0 } as Chain };
-  
-    await expect(async () =>
-      resolveL1OpStackContractAddress(
-        {
-          l2Chain: base,
-          chain: mockClient.chain,
-          contract: OpStackL1Contract.OptimismPortal,
-        },
-      )
-    ).rejects.toThrowError('Chain ID "0" does not match expected L1 chain ID "1"');
-});
-    
+  // Create a mock of publicClient with the modified chain ID
+  const mockClient = { ...publicClient, chain: { id: 0 } as Chain }
+
+  await expect(async () =>
+    resolveL1OpStackContractAddress(
+      {
+        l2Chain: base,
+        chain: mockClient.chain,
+        contract: OpStackL1Contract.OptimismPortal,
+      },
+    )
+  ).rejects.toThrowError('Chain ID "0" does not match expected L1 chain ID "1"')
+})


### PR DESCRIPTION
Interested to get feedback on this one. Could be more elegant I think.

Would like @roninjin10's eyes on it.

Update: Can't get the type error to go away unless I provide the `address` param yet the function resolves every address I've given it so unsure how to mock the `L2ChainOrAddressError`.