### PR TITLE
chore: add .npmrc for npm workspace

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-workspace-root-check=true
+


### PR DESCRIPTION
Add ignore-workspace-root-check so you can install node modules without `-w` flag