### PR TITLE
chore: Add only-allow

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "format:check": "dprint check",
     "lint": "biome check .",
     "lint:fix": "pnpm lint --apply",
+    "preinstall": "npx only-allow pnpm",
     "test": "vitest dev",
     "test:cov": "vitest dev --coverage",
     "test:ci": "CI=true vitest --coverage",


### PR DESCRIPTION
Add only-allow utility which will throw an error if someone accidentally installs with a package manager other than pnpm 

<img width="614" alt="image" src="https://github.com/base-org/op-viem/assets/35039927/b64d9f52-6e19-4e6d-b209-696b84d7829b">
