### PR TITLE
Fix getTransactionHash to use un-decorated function for better tree shaking

### DIFF
--- a/.changeset/honest-cows-deliver.md
+++ b/.changeset/honest-cows-deliver.md
@@ -1,0 +1,5 @@
+---
+"op-viem": patch
+---
+
+Fix getTransactionHash to use un-decorated function for better tree shaking

--- a/src/actions/public/L1/getL2HashesForDepositTx.ts
+++ b/src/actions/public/L1/getL2HashesForDepositTx.ts
@@ -1,6 +1,7 @@
 import type { Chain, Hash, PublicClient, TransactionReceipt, Transport } from 'viem'
 import { getL2HashFromL1DepositInfo } from '../../../utils/getL2HashFromL1DepositInfo.js'
 import { getTransactionDepositedEvents } from '../../../utils/getTransactionDepositedEvents.js'
+import { getTransactionReceipt } from 'viem/actions'
 
 export type GetL2HashesForDepositTxParamters = {
   l1TxHash: Hash
@@ -19,7 +20,7 @@ export async function getL2HashesForDepositTx<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
   { l1TxHash, l1TxReceipt }: GetL2HashesForDepositTxParamters,
 ): Promise<GetL2HashesForDepositTxReturnType> {
-  const txReceipt = l1TxReceipt ?? await client.getTransactionReceipt({ hash: l1TxHash })
+  const txReceipt = l1TxReceipt ?? await getTransactionReceipt(client, { hash: l1TxHash })
   const depositEvents = getTransactionDepositedEvents({ txReceipt })
 
   return depositEvents.map(({ event, logIndex }) =>

--- a/src/actions/public/L1/getL2HashesForDepositTx.ts
+++ b/src/actions/public/L1/getL2HashesForDepositTx.ts
@@ -1,7 +1,7 @@
 import type { Chain, Hash, PublicClient, TransactionReceipt, Transport } from 'viem'
+import { getTransactionReceipt } from 'viem/actions'
 import { getL2HashFromL1DepositInfo } from '../../../utils/getL2HashFromL1DepositInfo.js'
 import { getTransactionDepositedEvents } from '../../../utils/getTransactionDepositedEvents.js'
-import { getTransactionReceipt } from 'viem/actions'
 
 export type GetL2HashesForDepositTxParamters = {
   l1TxHash: Hash

--- a/src/actions/public/L2/getWithdrawalMessages.ts
+++ b/src/actions/public/L2/getWithdrawalMessages.ts
@@ -1,6 +1,7 @@
 import { l2ToL1MessagePasserABI } from '@eth-optimism/contracts-ts'
 import { type Chain, decodeEventLog, type Hash, type PublicClient, type TransactionReceipt, type Transport } from 'viem'
 import type { MessagePassedEvent } from '../../../types/withdrawal.js'
+import { getTransactionReceipt } from 'viem/actions'
 
 export type GetWithdrawalMessagesParameters = {
   hash: Hash
@@ -23,7 +24,7 @@ export async function getWithdrawalMessages<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
   { hash, txReceipt }: GetWithdrawalMessagesParameters,
 ): Promise<GetWithdrawalMessagesReturnType> {
-  const receipt = txReceipt ?? await client.getTransactionReceipt({ hash })
+  const receipt = txReceipt ?? await getTransactionReceipt(client, { hash })
   const messages: MessagePassedEvent[] = []
   for (const log of receipt.logs) {
     /// These transactions will contain events from several contracts

--- a/src/actions/public/L2/getWithdrawalMessages.ts
+++ b/src/actions/public/L2/getWithdrawalMessages.ts
@@ -1,7 +1,7 @@
 import { l2ToL1MessagePasserABI } from '@eth-optimism/contracts-ts'
 import { type Chain, decodeEventLog, type Hash, type PublicClient, type TransactionReceipt, type Transport } from 'viem'
-import type { MessagePassedEvent } from '../../../types/withdrawal.js'
 import { getTransactionReceipt } from 'viem/actions'
+import type { MessagePassedEvent } from '../../../types/withdrawal.js'
 
 export type GetWithdrawalMessagesParameters = {
   hash: Hash


### PR DESCRIPTION
Not using the functions extended from `client` allows for bundlers to tree shake more effectively