### PR TITLE
chore: update writeDepositETH to use writeDepositTransaction

### DIFF
--- a/site/docs/actions/public/L1/simulateDepositETH.md
+++ b/site/docs/actions/public/L1/simulateDepositETH.md
@@ -15,7 +15,7 @@ const publicClient = createPublicClient({
 const { request } = await publicClient.simulateDepositETH({
   args: {
     to: '0xFd4F24676eD4588928213F37B126B53c07186F45',
-    minGasLimit: 100000,
+    gasLimit: 100000,
   },
   value: 1n,
   l2chain: base,
@@ -35,7 +35,7 @@ Returns a `request` that can be passed to Viem's `writeContract` and a `result` 
 
 The address to deposit the tokens to.
 
-### minGasLimit
+### gasLimit
 
 - **Type:** `number`
 

--- a/site/docs/actions/wallet/L1/writeDepositETH.md
+++ b/site/docs/actions/wallet/L1/writeDepositETH.md
@@ -14,7 +14,7 @@ const walletClient = createWalletClient({
 const hash = await walletClient.writeDepositETH({
   args: {
     to: '0xFd4F24676eD4588928213F37B126B53c07186F45',
-    minGasLimit: 100000,
+    gasLimit: 100000,
   },
   value: 1n,
   l2chain: base,
@@ -34,7 +34,7 @@ Returns a transaction hash of the deposit transaction.
 
 The address to deposit the tokens to.
 
-### minGasLimit
+### gasLimit
 
 - **Type:** `number`
 

--- a/src/actions/public/L1/simulateDepositETH.test.ts
+++ b/src/actions/public/L1/simulateDepositETH.test.ts
@@ -9,7 +9,7 @@ test('default', async () => {
   const { request } = await simulateDepositETH(publicClient, {
     args: {
       to: accounts[0].address,
-      minGasLimit: 100000,
+      gasLimit: 100000,
     },
     value: 1n,
     l2Chain: base,

--- a/src/actions/public/L1/simulateDepositETH.ts
+++ b/src/actions/public/L1/simulateDepositETH.ts
@@ -26,17 +26,19 @@ export async function simulateDepositETH<
 >(
   client: PublicClient<Transport, TChain>,
   {
-    args: { to, minGasLimit, extraData = '0x' },
-    l1StandardBridgeAddress,
+    args: { to, gasLimit, extraData = '0x' },
+    optimismPortalAddress,
+    value,
     ...rest
   }: SimulateDepositETHParameters<TChain, TChainOverride>,
 ): Promise<SimulateDepositETHReturnType<TChain, TChainOverride>> {
   return simulateOpStackL1(client, {
-    address: l1StandardBridgeAddress,
+    address: optimismPortalAddress,
     abi: ABI,
     contract: CONTRACT,
     functionName: FUNCTION,
-    args: [to, minGasLimit, extraData],
+    args: [to, value, gasLimit, false, extraData],
+    value,
     ...rest,
   } as unknown as SimulateOpStackL1Parameters<TChain, TChainOverride, typeof ABI, typeof FUNCTION>)
 }

--- a/src/actions/public/L1/simulateDepositETH.ts
+++ b/src/actions/public/L1/simulateDepositETH.ts
@@ -26,7 +26,7 @@ export async function simulateDepositETH<
 >(
   client: PublicClient<Transport, TChain>,
   {
-    args: { to, gasLimit, extraData = '0x' },
+    args: { to, gasLimit, data = '0x' },
     optimismPortalAddress,
     value,
     ...rest
@@ -37,7 +37,7 @@ export async function simulateDepositETH<
     abi: ABI,
     contract: CONTRACT,
     functionName: FUNCTION,
-    args: [to, value, gasLimit, false, extraData],
+    args: [to, value, gasLimit, false, data],
     value,
     ...rest,
   } as unknown as SimulateOpStackL1Parameters<TChain, TChainOverride, typeof ABI, typeof FUNCTION>)

--- a/src/actions/wallet/L1/writeDepositETH.test.ts
+++ b/src/actions/wallet/L1/writeDepositETH.test.ts
@@ -9,7 +9,7 @@ test('default', async () => {
     await writeDepositETH(walletClient, {
       args: {
         to: accounts[0].address,
-        minGasLimit: 21000,
+        gasLimit: 21000,
         extraData: '0x',
       },
       value: 1n,

--- a/src/actions/wallet/L1/writeDepositETH.test.ts
+++ b/src/actions/wallet/L1/writeDepositETH.test.ts
@@ -1,12 +1,12 @@
+import { optimismPortalABI } from '@eth-optimism/contracts-ts'
+import { decodeEventLog, encodePacked } from 'viem'
+import { mine } from 'viem/actions'
 import { expect, test } from 'vitest'
 import { accounts } from '../../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../../_test/utils.js'
 import { base } from '../../../chains/index.js'
-import { writeDepositETH } from './writeDepositETH.js'
 import type { DepositETHParameters, TransactionDepositedEvent } from '../../../index.js'
-import { mine } from 'viem/actions'
-import { decodeEventLog, encodePacked } from 'viem'
-import { optimismPortalABI } from '@eth-optimism/contracts-ts'
+import { writeDepositETH } from './writeDepositETH.js'
 
 test('default', async () => {
   expect(

--- a/src/actions/wallet/L1/writeDepositETH.test.ts
+++ b/src/actions/wallet/L1/writeDepositETH.test.ts
@@ -1,8 +1,12 @@
 import { expect, test } from 'vitest'
 import { accounts } from '../../../_test/constants.js'
-import { walletClient } from '../../../_test/utils.js'
+import { publicClient, testClient, walletClient } from '../../../_test/utils.js'
 import { base } from '../../../chains/index.js'
 import { writeDepositETH } from './writeDepositETH.js'
+import type { DepositETHParameters, TransactionDepositedEvent } from '../../../index.js'
+import { mine } from 'viem/actions'
+import { decodeEventLog, encodePacked } from 'viem'
+import { optimismPortalABI } from '@eth-optimism/contracts-ts'
 
 test('default', async () => {
   expect(
@@ -10,11 +14,45 @@ test('default', async () => {
       args: {
         to: accounts[0].address,
         gasLimit: 21000,
-        extraData: '0x',
+        data: '0x',
       },
       value: 1n,
       l2Chain: base,
       account: accounts[0].address,
     }),
   ).toBeDefined()
+})
+
+test('correctly deposits ETH', async () => {
+  const args: DepositETHParameters = {
+    to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
+    gasLimit: 25000,
+    data: '0x',
+  }
+  const value = 1n
+  const hash = await writeDepositETH(walletClient, {
+    args,
+    value,
+    l2Chain: base,
+    account: accounts[0].address,
+  })
+
+  await mine(testClient, { blocks: 1 })
+
+  const r = await publicClient.getTransactionReceipt({ hash })
+  expect(r.logs.length).toEqual(1)
+  const depositEvent = decodeEventLog({
+    abi: optimismPortalABI,
+    data: r.logs[0].data,
+    topics: r.logs[0].topics,
+  })
+  expect(depositEvent.eventName).toEqual('TransactionDeposited')
+  const deposit = depositEvent as TransactionDepositedEvent
+  expect(deposit.args.from.toLowerCase()).toEqual(accounts[0].address)
+  expect(deposit.args.to.toLowerCase()).toEqual(args.to)
+  const expectOpaqueData = encodePacked(
+    ['uint', 'uint', 'uint64', 'bool', 'bytes'],
+    [value, value, BigInt(args.gasLimit), false, '0x'],
+  )
+  expect(deposit.args.opaqueData).toEqual(expectOpaqueData)
 })

--- a/src/actions/wallet/L1/writeDepositETH.ts
+++ b/src/actions/wallet/L1/writeDepositETH.ts
@@ -1,7 +1,7 @@
 import type { Account, Chain, Transport, WalletClient, WriteContractReturnType } from 'viem'
 import { ABI, CONTRACT, type DepositETHParameters, FUNCTION } from '../../../types/depositETH.js'
 import type { L1WriteActionBaseType } from '../../../types/l1Actions.js'
-import { writeOpStackL1, type WriteOpStackL1Parameters } from './writeOpStackL1.js'
+import { writeDepositTransaction, type WriteDepositTransactionParameters } from './writeDepositTransaction.js'
 
 export type WriteDepositETHParameters<
   TChain extends Chain | undefined = Chain,
@@ -19,7 +19,7 @@ export type WriteDepositETHParameters<
   >
 
 /**
- * Deposits ETH to L2 using the standard messenger contract
+ * Deposits ETH to L2 using the OptimismPortal contract
  * @param parameters - {@link WriteDepositETHParameters}
  * @returns A [Transaction Hash](https://viem.sh/docs/glossary/terms.html#hash). {@link WriteContractReturnType}
  */
@@ -30,7 +30,7 @@ export async function writeDepositETH<
 >(
   client: WalletClient<Transport, TChain, TAccount>,
   {
-    args: { to, gasLimit, extraData = '0x' },
+    args: { to, gasLimit, data },
     optimismPortalAddress,
     value,
     ...rest
@@ -40,19 +40,14 @@ export async function writeDepositETH<
     TChainOverride
   >,
 ): Promise<WriteContractReturnType> {
-  return writeOpStackL1(client, {
-    address: optimismPortalAddress,
-    abi: ABI,
-    contract: CONTRACT,
-    functionName: FUNCTION,
-    args: [to, value, gasLimit, false, extraData],
+  return writeDepositTransaction(client, {
+    args: {to, value, gasLimit: BigInt(gasLimit), data},
+    optimismPortalAddress,
     value,
     ...rest,
-  } as unknown as WriteOpStackL1Parameters<
+  } as unknown as WriteDepositTransactionParameters<
     TChain,
     TAccount,
-    TChainOverride,
-    typeof ABI,
-    typeof FUNCTION
+    TChainOverride
   >)
 }

--- a/src/actions/wallet/L1/writeDepositETH.ts
+++ b/src/actions/wallet/L1/writeDepositETH.ts
@@ -30,8 +30,9 @@ export async function writeDepositETH<
 >(
   client: WalletClient<Transport, TChain, TAccount>,
   {
-    args: { to, minGasLimit, extraData = '0x' },
-    l1StandardBridgeAddress,
+    args: { to, gasLimit, extraData = '0x' },
+    optimismPortalAddress,
+    value,
     ...rest
   }: WriteDepositETHParameters<
     TChain,
@@ -40,11 +41,12 @@ export async function writeDepositETH<
   >,
 ): Promise<WriteContractReturnType> {
   return writeOpStackL1(client, {
-    address: l1StandardBridgeAddress,
+    address: optimismPortalAddress,
     abi: ABI,
     contract: CONTRACT,
     functionName: FUNCTION,
-    args: [to, minGasLimit, extraData],
+    args: [to, value, gasLimit, false, extraData],
+    value,
     ...rest,
   } as unknown as WriteOpStackL1Parameters<
     TChain,

--- a/src/actions/wallet/L1/writeDepositETH.ts
+++ b/src/actions/wallet/L1/writeDepositETH.ts
@@ -41,7 +41,7 @@ export async function writeDepositETH<
   >,
 ): Promise<WriteContractReturnType> {
   return writeDepositTransaction(client, {
-    args: {to, value, gasLimit: BigInt(gasLimit), data},
+    args: { to, value, gasLimit: BigInt(gasLimit), data },
     optimismPortalAddress,
     value,
     ...rest,

--- a/src/types/depositETH.ts
+++ b/src/types/depositETH.ts
@@ -9,5 +9,5 @@ export const FUNCTION = 'depositTransaction'
 export type DepositETHParameters = {
   to: Address
   gasLimit: number
-  extraData?: Hex
+  data?: Hex
 }

--- a/src/types/depositETH.ts
+++ b/src/types/depositETH.ts
@@ -1,13 +1,13 @@
-import { l1StandardBridgeABI } from '@eth-optimism/contracts-ts'
+import { optimismPortalABI } from '@eth-optimism/contracts-ts'
 import type { Address, Hex } from 'viem'
 import { OpStackL1Contract } from './opStackContracts.js'
 
-export const ABI = l1StandardBridgeABI
-export const CONTRACT = OpStackL1Contract.L1StandardBridge
-export const FUNCTION = 'depositETHTo'
+export const ABI = optimismPortalABI
+export const CONTRACT = OpStackL1Contract.OptimismPortal
+export const FUNCTION = 'depositTransaction'
 
 export type DepositETHParameters = {
   to: Address
-  minGasLimit: number
+  gasLimit: number
   extraData?: Hex
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,10 +16,10 @@ export default defineConfig({
     // maxThreads: 1,
     // minThreads: 1,
     coverage: {
-      lines: 97.29,
-      statements: 97.29,
-      functions: 90.24,
-      branches: 90.9,
+      lines: 97.47,
+      statements: 97.47,
+      functions: 90.47,
+      branches: 91.46,
       thresholdAutoUpdate: true,
       reporter: ['text', 'json-summary', 'json'],
       exclude: [


### PR DESCRIPTION
updating `writeDepositETH` to use `writeDepositTransaction` on the `OptimismPortal` contract instead of `depositETHTo` on the standard bridge

- updated `writeDepositETH` to use `writeDepositTransaction`
- updated args to reflect contract
- added a test
- updated docs