### PR TITLE
Fix type exports build

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
-    "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
+    "build:types": "tsc --project tsconfig.build.json --module esnext --outDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "release:check": "changeset status --verbose --since=origin/main",
     "release:publish": "pnpm install && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/types/index.d.ts",
   "typings": "./dist/types/index.d.ts",
   "sideEffects": false,
+  "license": "MIT",
   "files": [
     "dist",
     "!dist/**/*.tsbuildinfo",


### PR DESCRIPTION
Latest version released did not have types, oddly `pnpm run build:types` did not emit any types when using `declarationDir`, I'm not sure if there's an obscure interaction going on between all the CLI flags but it works when using `outDir`.