### PR TITLE
Remove stray references to the old l2chain API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 import { createWalletClient, createPublicClient, custom, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet, base } from 'viem/chains'
+import { baseAddresses } from 'op-viem/chains'
 import { walletL1OpStackActions, publicL1OpStackActions, publicL2OpStackActions } from 'op-viem'
 
 // create clients
@@ -45,7 +46,7 @@ export const opStackL2PublicClient = createPublicClient({
 }).extend(publicL2OpStackActions)
 
 // perform an action
-opStackL1PublicClient.getOutputForL2Block(blockNumber: 2725977n, l2Chain: base)
+opStackL1PublicClient.getOutputForL2Block(blockNumber: 2725977n, ...baseAddresses)
 ```
 
 ## Community

--- a/site/docs/actions/public/L1/simulateProveWithdrawalTransaction.md
+++ b/site/docs/actions/public/L1/simulateProveWithdrawalTransaction.md
@@ -6,7 +6,7 @@ Simulates [writeProveWithdrawalTransactoin](/docs/actions/wallet/L1/writeProveWi
 
 ```ts [example.ts]
 import { ProveWithdrawalTransactionArgs } from 'op-viem'
-import { base } from 'op-viem/chains'
+import { baseAddresses } from 'op-viem/chains'
 import { opStackL1PublicClient, opStackL2PublicClient } from './config'
 
 // with static args
@@ -48,7 +48,7 @@ const withdrawalMessages = await opStackL2PublicClient.getWithdrawalMessages({
 
 const output = await opStackL1PublicClient.getOutputForL2Block({
   l2BlockNumber: withdrawalMessages.blockNumber,
-  l2Chain: base,
+  baseAddresses,
 })
 
 const args = await opStackL2PublicClient.getProveWithdrawalTransactionArgs({
@@ -58,7 +58,7 @@ const args = await opStackL2PublicClient.getProveWithdrawalTransactionArgs({
 
 const hash = await opStackL1PublicClient.simulateProveWithdrawalTransaction({
   args,
-  l2Chain: base,
+  baseAddresses,
 })
 ```
 
@@ -135,34 +135,21 @@ await walletClient.simulateProveWithdrawalTransaction({
       '0xf851808080a0416fd1169258cec24c52324935014bf4f68f3536180a4602708b5cd521a2659e8080a0b01b31a59349372e45452b61e689ecbfe33939eb609207f4b650c173c05722bf80808080808080808080',
       '0xe09e3244a3f2d3e778ea2b2c739f085da3cf4453befda1c8c31c84e17e18a39301',
     ],
-  }
-  l2Chain: base,
+  },
+  ...baseAddresses,
 })
 ```
 
-### l2Chain (optional)
+### portal(optional)
 
-- **Type:** `OpStackChain`
+- **Type:** [`RawOrContractAddress`](https://viem.sh/docs/glossary/types#raworcontractaddress)
 
-The chain on which the withdrawal was initiated, used to determine which `OptimismPortal` to call.
+The `OptimismPortal` contract where the sendMessage call should be made.
 
 ```ts
 await walletClient.simulateProveWithdrawalTransaction({
   args,
-  l2Chain: base, // [!code focus:1]
-})
-```
-
-### portalAddress (optional)
-
-- **Type:** [`Address`](https://viem.sh/docs/glossary/types#address)
-
-The `OptimismPortal` contract where the sendMessage call should be made. MUST be specified if [l2Chain](#l2chain-optional) not passed.
-
-```ts
-await walletClient.simulateProveWithdrawalTransaction({
-  args,
-  portalAddress: '0x49048044D57e1C92A77f79988d21Fa8fAF74E97e', // [!code focus:1]
+  portal: '0x49048044D57e1C92A77f79988d21Fa8fAF74E97e', // [!code focus:1]
 })
 ```
 

--- a/site/docs/actions/wallet/L1/writeDepositTransaction.md
+++ b/site/docs/actions/wallet/L1/writeDepositTransaction.md
@@ -116,7 +116,7 @@ await walletClient.writeDepositTransaction({
     gasLimit: 21000n,
     isCreation: false,
   },
-  l2Chain: base,
+  ...baseAddresses,
 })
 ```
 

--- a/site/docs/examples.md
+++ b/site/docs/examples.md
@@ -3,7 +3,7 @@
 ::: code-group
 
 ```ts [index.ts]
-import { baseGoerli } from 'op-viem/chains'
+import { baseGoerliAddresses } from 'op-viem/chains'
 import {
   account,
   l1PublicClient,
@@ -18,7 +18,7 @@ const depositTxHash = await l1WalletClient.writeDepositETH({
     minGasLimit: 21000,
   },
   value: 1n,
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
 })
 
 const txReceipt = await l1PublicClient.waitForTransactionReceipt({
@@ -72,7 +72,7 @@ export const l2PublicClient = createPublicClient({
 ::: code-group
 
 ```ts [index.ts]
-import { baseGoerli } from 'op-viem/chains'
+import { baseGoerliAddresses } from 'op-viem/chains'
 import {
   account,
   l1PublicClient,
@@ -99,12 +99,12 @@ const withdrawalMessages = await l2PublicClient.getWithdrawalMessages({
 })
 const output = await l1PublicClient.getOutputForL2Block({
   l2BlockNumber: withdrawalMessages.blockNumber,
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
 })
 
 const l2BlockNumber = await l2PublicClient.getBlockNumber()
 const secondsToProve = await l1PublicClient.getSecondsToNextL2Output({
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
   latestL2BlockNumber: l2BlockNumber,
 })
 
@@ -119,19 +119,19 @@ const proveWithdrawalArgs = await l2PublicClient
 const proveWithdrawalTxHash = await l1WalletClient
   .writeProveWithdrawalTransaction({
     args: proveWithdrawalArgs,
-    l2Chain: baseGoerli,
+    ...baseGoerliAddresses,
   })
 
 await l1PublicClient.waitForTransactionReceipt({ hash: proveWithdrawalTxHash })
 
 const provenWithdrawal = await l1PublicClient.readProvenWithdrawals({
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
   withdrawalHash: withdrawalMessages.messages[0].withdrawalHash,
 })
 console.log('provenWithdrawal', provenWithdrawal)
 
 const secondsToFinalize = await l1PublicClient.getSecondsToFinalizable({
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
   withdrawalHash: withdrawalMessages.messages[0].withdrawalHash,
 })
 
@@ -140,7 +140,7 @@ const secondsToFinalize = await l1PublicClient.getSecondsToFinalizable({
 const { withdrawalHash, ...withdrawal } = withdrawalMessages.messages[0]
 const finalizeTxHash = await l1WalletClient.writeFinalizeWithdrawalTransaction({
   withdrawal,
-  l2Chain: baseGoerli,
+  ...baseGoerliAddresses,
 })
 console.log('finalizeTxHash', finalizeTxHash)
 ```

--- a/site/index.md
+++ b/site/index.md
@@ -40,6 +40,7 @@ bun i op-viem
 import { createWalletClient, createPublicClient, custom, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet, base } from 'viem/chains'
+import { baseAddresses } from 'op-viem/chains'
 import { walletL1OpStackActions, publicL1OpStackActions, publicL2OpStackActions } from 'op-viem'
 
 // create clients
@@ -59,5 +60,5 @@ export const opStackL2PublicClient = createPublicClient({
 }).extend(publicL2OpStackActions)
 
 // perform an action
-opStackL1PublicClient.getOutputForL2Block(blockNumber: 2725977n, l2Chain: base)
+opStackL1PublicClient.getOutputForL2Block(blockNumber: 2725977n, ...baseAddresses)
 ```


### PR DESCRIPTION
Removes remaining references to the old l2Chain API from documentation.