### PR TITLE
👷 chore: Remove prerelease workflow follow up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
       # https://github.com/changesets/action#with-publishing
       - name: Handle Release Pull Request or Publish to npm
         id: changesets
-        if: steps.check_files.outputs.files_exists == 'false'
         uses: changesets/action@v1
         with:
           title: "chore: version packages 🔖"


### PR DESCRIPTION
Last pr https://github.com/base-org/op-viem/pull/158 there was a line of config that got missed when deleting prerelease code