### PR TITLE
Ensure export coverage

### DIFF
--- a/.changeset/honest-mails-check.md
+++ b/.changeset/honest-mails-check.md
@@ -1,0 +1,5 @@
+---
+"op-viem": minor
+---
+
+Export more types and ensure that we export every action defined.

--- a/src/_test/constants.ts
+++ b/src/_test/constants.ts
@@ -70,7 +70,7 @@ export let forkUrl: string
 if (process.env.VITE_ANVIL_FORK_URL) {
   forkUrl = process.env.VITE_ANVIL_FORK_URL
 } else {
-  forkUrl = 'https://cloudflare-eth.com'
+  forkUrl = 'https://ethereum.publicnode.com'
   warn(`\`VITE_ANVIL_FORK_URL\` not found. Falling back to \`${forkUrl}\`.`)
 }
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,9 +1,16 @@
 export { type AccountProof, getProof, type GetProofParameters, type StorageProof } from './public/getProof.js'
+
+// Public L1 actions
 export {
   getL2HashesForDepositTx,
   type GetL2HashesForDepositTxParamters,
   type GetL2HashesForDepositTxReturnType,
 } from './public/L1/getL2HashesForDepositTx.js'
+export {
+  getLatestProposedL2BlockNumber,
+  type GetLatestProposedL2BlockNumberParameters,
+  type GetLatestProposedL2BlockNumberReturnType,
+} from './public/L1/getLatestProposedL2BlockNumber.js'
 export {
   getOutputForL2Block,
   type GetOutputForL2BlockParameters,
@@ -36,10 +43,17 @@ export {
   type SimulateDepositTransactionReturnType,
 } from './public/L1/simulateDepositTransaction.js'
 export {
+  simulateFinalizeWithdrawalTransaction,
+  type SimulateFinalizeWithdrawalTransactionParameters,
+  type SimulateFinalizeWithdrawalTransactionReturnType,
+} from './public/L1/simulateFinalizeWithdrawalTransaction.js'
+export {
   simulateProveWithdrawalTransaction,
   type SimulateProveWithdrawalTransactionParameters,
   type SimulateProveWithdrawalTransactionReturnType,
 } from './public/L1/simulateProveWithdrawalTransaction.js'
+
+// Public L2 actions
 export { estimateFees, type EstimateFeesParameters } from './public/L2/estimateFees.js'
 export { estimateL1Fee, type EstimateL1FeeParameters } from './public/L2/estimateL1Fee.js'
 export { estimateL1GasUsed, type EstimateL1GasUsedParameters } from './public/L2/estimateL1GasUsed.js'
@@ -65,6 +79,7 @@ export {
   type SimulateWithdrawETHReturnType,
 } from './public/L2/simulateWithdrawETH.js'
 
+// Wallet L1 actions
 export { writeContractDeposit, type WriteContractDepositParameters } from './wallet/L1/writeContractDeposit.js'
 export { writeDepositERC20, type WriteDepositERC20Parameters } from './wallet/L1/writeDepositERC20.js'
 export { writeDepositETH, type WriteDepositETHParameters } from './wallet/L1/writeDepositETH.js'
@@ -86,5 +101,7 @@ export {
   writeSendMessage,
   type WriteSendMessageParameters,
 } from './wallet/L1/writeSendMessage.js'
+
+// Wallet l2 actions
 export { writeWithdrawERC20, type WriteWithdrawERC20Parameters } from './wallet/L2/writeWithdrawERC20.js'
 export { writeWithdrawETH, type WriteWithdrawETHParameters } from './wallet/L2/writeWithdrawETH.js'

--- a/src/actions/public/L1/getLatestProposedL2BlockNumber.test.ts
+++ b/src/actions/public/L1/getLatestProposedL2BlockNumber.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+import { publicClient } from '../../../_test/utils.js'
+import { baseAddresses } from '../../../chains/index.js'
+import { getLatestProposedL2BlockNumber } from './getLatestProposedL2BlockNumber.js'
+
+test('retrieves correctly', async () => {
+  const result = await getLatestProposedL2BlockNumber(publicClient, {
+    ...baseAddresses,
+  })
+  expect(result.l2BlockNumber).toBeDefined()
+})

--- a/src/actions/public/L1/getSecondsToNextL2Output.test.ts
+++ b/src/actions/public/L1/getSecondsToNextL2Output.test.ts
@@ -1,6 +1,7 @@
 import { createPublicClient, http } from 'viem'
-import { base, mainnet } from 'viem/chains'
+import { base } from 'viem/chains'
 import { expect, test } from 'vitest'
+import { publicClient } from '../../../_test/utils.js'
 import { baseAddresses } from '../../../chains/base.js'
 import { getSecondsToNextL2Output } from './getSecondsToNextL2Output.js'
 
@@ -11,12 +12,7 @@ test('get seconds to next L2 output', async () => {
   })
   const latestL2BlockNumber = await l2Client.getBlockNumber()
 
-  const l1Client = createPublicClient({
-    chain: mainnet,
-    transport: http(),
-  })
-
-  const time = await getSecondsToNextL2Output(l1Client, { latestL2BlockNumber, ...baseAddresses })
+  const time = await getSecondsToNextL2Output(publicClient, { latestL2BlockNumber, ...baseAddresses })
   expect(time).toBeDefined()
   // this is too noisy to node issues,
   // but I do think we should revert if latestL2BlockNumber

--- a/src/actions/public/L2/getProveWithdrawalTransactionArgs.test.ts
+++ b/src/actions/public/L2/getProveWithdrawalTransactionArgs.test.ts
@@ -1,8 +1,8 @@
 import { createPublicClient, http } from 'viem'
-import { base, mainnet } from 'viem/chains'
+import { base } from 'viem/chains'
 import { expect, test } from 'vitest'
 import { accounts } from '../../../_test/constants.js'
-import { walletClient } from '../../../_test/utils.js'
+import { publicClient, walletClient } from '../../../_test/utils.js'
 import { baseAddresses } from '../../../chains/index.js'
 import { writeProveWithdrawalTransaction } from '../../index.js'
 import { getLatestProposedL2BlockNumber } from '../L1/getLatestProposedL2BlockNumber.js'
@@ -21,17 +21,11 @@ test('correctly generates args', async () => {
     hash: '0xd0eb2a59f3cc4c61b01c350e71e1804ad6bd776dc9abc1bdb5e2e40695ab2628',
   })
 
-  // TODO: using publicClient was giving issues in CI, need to solve
-  const l1Client = createPublicClient({
-    chain: mainnet,
-    transport: http(),
-  })
-
-  const { l2BlockNumber } = await getLatestProposedL2BlockNumber(l1Client, {
+  const { l2BlockNumber } = await getLatestProposedL2BlockNumber(publicClient, {
     ...baseAddresses,
   })
 
-  const output = await getOutputForL2Block(l1Client, {
+  const output = await getOutputForL2Block(publicClient, {
     l2BlockNumber,
     ...baseAddresses,
   })

--- a/src/decorators/publicL1OpStackActions.ts
+++ b/src/decorators/publicL1OpStackActions.ts
@@ -5,6 +5,11 @@ import {
   type GetL2HashesForDepositTxReturnType,
 } from '../actions/public/L1/getL2HashesForDepositTx.js'
 import {
+  getLatestProposedL2BlockNumber,
+  type GetLatestProposedL2BlockNumberParameters,
+  type GetLatestProposedL2BlockNumberReturnType,
+} from '../actions/public/L1/getLatestProposedL2BlockNumber.js'
+import {
   getOutputForL2Block,
   type GetOutputForL2BlockParameters,
   type GetOutputForL2BlockReturnType,
@@ -42,6 +47,11 @@ import {
   type SimulateDepositTransactionReturnType,
 } from '../actions/public/L1/simulateDepositTransaction.js'
 import {
+  simulateFinalizeWithdrawalTransaction,
+  type SimulateFinalizeWithdrawalTransactionParameters,
+  type SimulateFinalizeWithdrawalTransactionReturnType,
+} from '../actions/public/L1/simulateFinalizeWithdrawalTransaction.js'
+import {
   simulateProveWithdrawalTransaction,
   type SimulateProveWithdrawalTransactionParameters,
   type SimulateProveWithdrawalTransactionReturnType,
@@ -53,35 +63,46 @@ export type PublicL1OpStackActions<
   getL2HashesForDepositTx: (
     args: GetL2HashesForDepositTxParamters,
   ) => Promise<GetL2HashesForDepositTxReturnType>
-  simulateDepositETH: <
-    TChainOverride extends Chain | undefined = Chain | undefined,
-  >(
-    args: SimulateDepositETHParameters<TChain, TChainOverride>,
-  ) => Promise<SimulateDepositETHReturnType<TChain, TChainOverride>>
+  getLatestProposedL2BlockNumber: (
+    args: GetLatestProposedL2BlockNumberParameters<TChain>,
+  ) => Promise<GetLatestProposedL2BlockNumberReturnType>
+  getOutputForL2Block: (
+    args: GetOutputForL2BlockParameters<TChain>,
+  ) => Promise<GetOutputForL2BlockReturnType>
+  getSecondsToFinalizable: (args: GetSecondsToFinalizableParameters<TChain>) => Promise<bigint>
+  getSecondsToNextL2Output: (
+    args: GetSecondsToNextL2OutputParameters<TChain>,
+  ) => Promise<bigint>
+
+  readFinalizedWithdrawals: (args: ReadFinalizedWithdrawalsParameters<TChain>) => Promise<boolean>
+  readProvenWithdrawals: (args: ReadProvenWithdrawalsParameters<TChain>) => Promise<ReadProvenWithdrawalsReturnType>
+
   simulateDepositERC20: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: SimulateDepositERC20Parameters<TChain, TChainOverride>,
   ) => Promise<SimulateDepositERC20ReturnType<TChain, TChainOverride>>
+  simulateDepositETH: <
+    TChainOverride extends Chain | undefined = Chain | undefined,
+  >(
+    args: SimulateDepositETHParameters<TChain, TChainOverride>,
+  ) => Promise<SimulateDepositETHReturnType<TChain, TChainOverride>>
   simulateDepositTransaction: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: SimulateDepositTransactionParameters<TChain, TChainOverride>,
   ) => Promise<SimulateDepositTransactionReturnType<TChain, TChainOverride>>
+
+  simulateFinalizeWithdrawalTransaction: <
+    TChainOverride extends Chain | undefined = Chain | undefined,
+  >(
+    args: SimulateFinalizeWithdrawalTransactionParameters<TChain, TChainOverride>,
+  ) => Promise<SimulateFinalizeWithdrawalTransactionReturnType<TChain, TChainOverride>>
   simulateProveWithdrawTransaction: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: SimulateProveWithdrawalTransactionParameters<TChain, TChainOverride>,
   ) => Promise<SimulateProveWithdrawalTransactionReturnType<TChain, TChainOverride>>
-  getOutputForL2Block: (
-    args: GetOutputForL2BlockParameters<TChain>,
-  ) => Promise<GetOutputForL2BlockReturnType>
-  getSecondsToNextL2Output: (
-    args: GetSecondsToNextL2OutputParameters<TChain>,
-  ) => Promise<bigint>
-  getSecondsToFinalizable: (args: GetSecondsToFinalizableParameters<TChain>) => Promise<bigint>
-  readProvenWithdrawals: (args: ReadProvenWithdrawalsParameters<TChain>) => Promise<ReadProvenWithdrawalsReturnType>
-  readFinalizedWithdrawals: (args: ReadFinalizedWithdrawalsParameters<TChain>) => Promise<boolean>
 }
 
 export function publicL1OpStackActions<
@@ -92,14 +113,20 @@ export function publicL1OpStackActions<
 ): PublicL1OpStackActions<TChain> {
   return {
     getL2HashesForDepositTx: (args) => getL2HashesForDepositTx(client, args),
+
+    getLatestProposedL2BlockNumber: (args) => getLatestProposedL2BlockNumber(client, args),
+    getOutputForL2Block: (args) => getOutputForL2Block(client, args),
+    getSecondsToFinalizable: (args) => getSecondsToFinalizable(client, args),
+    getSecondsToNextL2Output: (args) => getSecondsToNextL2Output(client, args),
+
     simulateDepositETH: (args) => simulateDepositETH(client, args),
     simulateDepositERC20: (args) => simulateDepositERC20(client, args),
     simulateDepositTransaction: (args) => simulateDepositTransaction(client, args),
-    getOutputForL2Block: (args) => getOutputForL2Block(client, args),
-    simulateProveWithdrawTransaction: (args) => simulateProveWithdrawalTransaction(client, args),
-    getSecondsToNextL2Output: (args) => getSecondsToNextL2Output(client, args),
-    getSecondsToFinalizable: (args) => getSecondsToFinalizable(client, args),
-    readProvenWithdrawals: (args) => readProvenWithdrawals(client, args),
+
     readFinalizedWithdrawals: (args) => readFinalizedWithdrawals(client, args),
+    readProvenWithdrawals: (args) => readProvenWithdrawals(client, args),
+
+    simulateFinalizeWithdrawalTransaction: (args) => simulateFinalizeWithdrawalTransaction(client, args),
+    simulateProveWithdrawTransaction: (args) => simulateProveWithdrawalTransaction(client, args),
   }
 }

--- a/src/decorators/publicL2OpStackActions.ts
+++ b/src/decorators/publicL2OpStackActions.ts
@@ -12,15 +12,20 @@ import {
   type GetWithdrawalMessagesParameters,
   type GetWithdrawalMessagesReturnType,
 } from '../actions/public/L2/getWithdrawalMessages.js'
+import {
+  simulateWithdrawERC20,
+  type SimulateWithdrawERC20Parameters,
+  type SimulateWithdrawERC20ReturnType,
+} from '../actions/public/L2/simulateWithdrawERC20.js'
+import {
+  simulateWithdrawETH,
+  type SimulateWithdrawETHParameters,
+  type SimulateWithdrawETHReturnType,
+} from '../actions/public/L2/simulateWithdrawETH.js'
+
 import { type OracleTransactionParameters } from '../types/gasPriceOracle.js'
 
-export type PublicL2OpStackActions = {
-  getWithdrawalMessages: (
-    args: GetWithdrawalMessagesParameters,
-  ) => Promise<GetWithdrawalMessagesReturnType>
-  getProveWithdrawalTransactionArgs: (
-    args: GetProveWithdrawalTransactionArgsParams,
-  ) => Promise<GetProveWithdrawalTransactionArgsReturnType>
+export type PublicL2OpStackActions<TChain extends Chain | undefined = Chain | undefined> = {
   /**
    * Estimate the l1 gas price portion for a transaction
    * @example
@@ -29,15 +34,44 @@ export type PublicL2OpStackActions = {
    *   blockTag,
    * });
    */
+  estimateFees: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
+    args: EstimateFeesParameters<TAbi, TFunctionName>,
+  ) => Promise<bigint>
   estimateL1Fee: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
     args: OracleTransactionParameters<TAbi, TFunctionName>,
   ) => Promise<bigint>
   estimateL1GasUsed: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
     args: OracleTransactionParameters<TAbi, TFunctionName>,
   ) => Promise<bigint>
-  estimateFees: <TAbi extends Abi | readonly unknown[], TFunctionName extends string | undefined = undefined>(
-    args: EstimateFeesParameters<TAbi, TFunctionName>,
-  ) => Promise<bigint>
+
+  getProveWithdrawalTransactionArgs: (
+    args: GetProveWithdrawalTransactionArgsParams,
+  ) => Promise<GetProveWithdrawalTransactionArgsReturnType>
+  getWithdrawalMessages: (
+    args: GetWithdrawalMessagesParameters,
+  ) => Promise<GetWithdrawalMessagesReturnType>
+
+  simulateWithdrawERC20: <
+    TChainOverride extends Chain | undefined = undefined,
+  >(
+    args: SimulateWithdrawERC20Parameters<TChain, TChainOverride>,
+  ) => Promise<
+    SimulateWithdrawERC20ReturnType<
+      TChain,
+      TChainOverride
+    >
+  >
+
+  simulateWithdrawETH: <
+    TChainOverride extends Chain | undefined = undefined,
+  >(
+    args: SimulateWithdrawETHParameters<TChain, TChainOverride>,
+  ) => Promise<
+    SimulateWithdrawETHReturnType<
+      TChain,
+      TChainOverride
+    >
+  >
 }
 
 export function publicL2OpStackActions<
@@ -45,12 +79,16 @@ export function publicL2OpStackActions<
   TChain extends Chain | undefined = Chain | undefined,
 >(
   client: PublicClient<TTransport, TChain>,
-): PublicL2OpStackActions {
+): PublicL2OpStackActions<TChain> {
   return {
-    getWithdrawalMessages: (args) => getWithdrawalMessages(client, args),
-    getProveWithdrawalTransactionArgs: (args) => getProveWithdrawalTransactionArgs(client, args),
+    estimateFees: (args) => estimateFees(client, args),
     estimateL1Fee: (args) => estimateL1Fee(client, args),
     estimateL1GasUsed: (args) => estimateL1GasUsed(client, args),
-    estimateFees: (args) => estimateFees(client, args),
+
+    getProveWithdrawalTransactionArgs: (args) => getProveWithdrawalTransactionArgs(client, args),
+    getWithdrawalMessages: (args) => getWithdrawalMessages(client, args),
+
+    simulateWithdrawERC20: (args) => simulateWithdrawERC20(client, args),
+    simulateWithdrawETH: (args) => simulateWithdrawETH(client, args),
   }
 }

--- a/src/decorators/walletL1OpStackActions.ts
+++ b/src/decorators/walletL1OpStackActions.ts
@@ -15,34 +15,39 @@ import {
   writeProveWithdrawalTransaction,
   type WriteProveWithdrawalTransactionParameters,
 } from '../actions/wallet/L1/writeProveWithdrawalTransaction.js'
+import { writeSendMessage, type WriteSendMessageParameters } from '../actions/wallet/L1/writeSendMessage.js'
 
 export type WalletL1OpStackActions<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
 > = {
-  writeDepositETH: <
+  writeContractDeposit: <
+    TAbi extends Abi | readonly unknown[] = Abi,
+    TFunctionName extends string = string,
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
-    args: WriteDepositETHParameters<TChain, TAccount, TChainOverride>,
+    args: WriteContractDepositParameters<
+      TAbi,
+      TFunctionName,
+      TChain,
+      TAccount,
+      TChainOverride
+    >,
   ) => Promise<WriteContractReturnType>
   writeDepositERC20: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: WriteDepositERC20Parameters<TChain, TAccount, TChainOverride>,
   ) => Promise<WriteContractReturnType>
+  writeDepositETH: <
+    TChainOverride extends Chain | undefined = Chain | undefined,
+  >(
+    args: WriteDepositETHParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<WriteContractReturnType>
   writeDepositTransaction: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
     args: WriteDepositTransactionParameters<
-      TChain,
-      TAccount,
-      TChainOverride
-    >,
-  ) => Promise<WriteContractReturnType>
-  writeProveWithdrawalTransaction: <
-    TChainOverride extends Chain | undefined = Chain | undefined,
-  >(
-    args: WriteProveWithdrawalTransactionParameters<
       TChain,
       TAccount,
       TChainOverride
@@ -57,18 +62,19 @@ export type WalletL1OpStackActions<
       TChainOverride
     >,
   ) => Promise<WriteContractReturnType>
-  writeContractDeposit: <
-    TAbi extends Abi | readonly unknown[] = Abi,
-    TFunctionName extends string = string,
+  writeProveWithdrawalTransaction: <
     TChainOverride extends Chain | undefined = Chain | undefined,
   >(
-    args: WriteContractDepositParameters<
-      TAbi,
-      TFunctionName,
+    args: WriteProveWithdrawalTransactionParameters<
       TChain,
       TAccount,
       TChainOverride
     >,
+  ) => Promise<WriteContractReturnType>
+  writeSendMessage: <
+    TChainOverride extends Chain | undefined = Chain | undefined,
+  >(
+    args: WriteSendMessageParameters<TChain, TAccount, TChainOverride>,
   ) => Promise<WriteContractReturnType>
 }
 
@@ -80,11 +86,12 @@ export function walletL1OpStackActions<
   client: WalletClient<TTransport, TChain, TAccount>,
 ): WalletL1OpStackActions<TChain, TAccount> {
   return {
-    writeDepositTransaction: (args) => writeDepositTransaction(client, args),
-    writeDepositETH: (args) => writeDepositETH(client, args),
-    writeDepositERC20: (args) => writeDepositERC20(client, args),
-    writeProveWithdrawalTransaction: (args) => writeProveWithdrawalTransaction(client, args),
-    writeFinalizeWithdrawalTransaction: (args) => writeFinalizeWithdrawalTranasction(client, args),
     writeContractDeposit: (args) => writeContractDeposit(client, args),
+    writeDepositERC20: (args) => writeDepositERC20(client, args),
+    writeDepositETH: (args) => writeDepositETH(client, args),
+    writeDepositTransaction: (args) => writeDepositTransaction(client, args),
+    writeFinalizeWithdrawalTransaction: (args) => writeFinalizeWithdrawalTranasction(client, args),
+    writeProveWithdrawalTransaction: (args) => writeProveWithdrawalTransaction(client, args),
+    writeSendMessage: (args) => writeSendMessage(client, args),
   }
 }

--- a/src/decorators/walletL2OpStackActions.ts
+++ b/src/decorators/walletL2OpStackActions.ts
@@ -28,7 +28,7 @@ export function walletL2OpStackActions<
   client: WalletClient<TTransport, TChain, TAccount>,
 ): WalletL2OpStackActions<TChain, TAccount> {
   return {
-    writeWithdrawETH: (args) => writeWithdrawETH(client, args),
     writeWithdrawERC20: (args) => writeWithdrawERC20(client, args),
+    writeWithdrawETH: (args) => writeWithdrawETH(client, args),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { type PublicL1OpStackActions, publicL1OpStackActions } from './decorator
 export { type PublicL2OpStackActions, publicL2OpStackActions } from './decorators/publicL2OpStackActions.js'
 export { type WalletL1OpStackActions, walletL1OpStackActions } from './decorators/walletL1OpStackActions.js'
 export { type WalletL2OpStackActions, walletL2OpStackActions } from './decorators/walletL2OpStackActions.js'
+export type { Addresses, ContractAddress, RawOrContractAddress } from './types/addresses.js'
 export type { DepositERC20Parameters } from './types/depositERC20.js'
 export type { DepositETHParameters } from './types/depositETH.js'
 export type { DepositTransaction, TransactionDepositedEvent } from './types/depositTransaction.js'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { parseOpaqueData } from './getArgsFromTransactionDepositedOpaqueData.js'
 export type { GetDepositTransactionParams } from './getDepositTransaction.js'
 export { getDepositTransaction } from './getDepositTransaction.js'
 export { getL2HashFromL1DepositInfo } from './getL2HashFromL1DepositInfo.js'


### PR DESCRIPTION
We didn't export `getLatestProposedL2BlockNumber` among other things. Sorted all exports to make problems like this easier to spot in the future.