### PR TITLE
Ignore changelog when formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -9,7 +9,8 @@
   },
   "excludes": [
     "**/node_modules",
-    "**/*-lock.json"
+    "**/*-lock.json",
+    "CHANGELOG.md"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.87.1.wasm",


### PR DESCRIPTION
The CHANGELOG has its own _valid_ and hard to configure way of formatting things which disagrees with dprint and breaks our release pipeline, so we'll ignore it.