### PR TITLE
Update the fallback anvil fork URL to use Cloudflare like viem does

### DIFF
--- a/src/_test/constants.ts
+++ b/src/_test/constants.ts
@@ -70,7 +70,7 @@ export let forkUrl: string
 if (process.env.VITE_ANVIL_FORK_URL) {
   forkUrl = process.env.VITE_ANVIL_FORK_URL
 } else {
-  forkUrl = 'https://ethereum.publicnode.com'
+  forkUrl = 'https://cloudflare-eth.com'
   warn(`\`VITE_ANVIL_FORK_URL\` not found. Falling back to \`${forkUrl}\`.`)
 }
 


### PR DESCRIPTION
Without this change, running the tests on a fresh checkout results in many failed tests with the following error repeated in the output:

```
Error: Anvil exited: thread 'main' panicked at /home/runner/work/foundry/foundry/crates/anvil/src/eth/backend/mem/mod.rs:238:39:
Failed to create genesis: GetAccount(0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266, (code: -32000, message: missing trie node 6be1147a8f956737d61a31ba05c807d2820b1559f30ca027abcc2dd5badbc544 (path ) state 0x6be1147a8f956737d61a31ba05c807d2820b1559f30ca027abcc2dd5badbc544 is not available, data: None)
```

Setting `VITE_ANVIL_FORK_URL` to point to an RPC from an Infura account resolves the issue, presumably because the current default, `https://ethereum.publicnode.com` is probably not an archive node. `viem` itself [falls back to using a Cloudflare node](https://github.com/wevm/viem/blob/7605bcd40b931ab961385bb86f4eeb69076711a2/test/src/constants.ts#L76), which also seems to solve the issue.

This pull request falls back to Cloudflare like `viem` does.