### PR TITLE
Fix Typo and Update References in Withdrawal Documentation

### DIFF
--- a/site/docs/actions/public/L1/readFinalizedWithdrawals.md
+++ b/site/docs/actions/public/L1/readFinalizedWithdrawals.md
@@ -1,6 +1,6 @@
 # readFinalizedWithdrawals
 
-Returns a boolean for whether the withdrawal of a given withdrawl hash has been finalized.
+Returns a boolean for whether the withdrawal of a given withdrawal hash has been finalized.
 
 ```ts [example.ts]
 import { publicL1Actions } from 'op-viem'

--- a/site/docs/actions/wallet/L1/writeContractDeposit.md
+++ b/site/docs/actions/wallet/L1/writeContractDeposit.md
@@ -86,7 +86,7 @@ The `OptimismPortal` contract, or equivalent, facilitating the L1 to L2 transiti
 
 ## Notes
 
-- The function will throw an error if `strict` is `true` and the `account` is a smart contract. This is to mitigate unexpected behavior due to [address aliasing](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#address-aliasing).
+- The function will throw an error if `strict` is `true` and the `account` is a smart contract. This is to mitigate unexpected behavior due to [address aliasing](https://github.com/ethereum-optimism/optimism/blob/master/specs/deposits.md#address-aliasing).
 
 - The function uses `encodeFunctionData` to create calldata for the L2 transaction, thus requiring ABI, function name, and args.
 

--- a/site/docs/actions/wallet/L1/writeProveWithdrawalTransaction.md
+++ b/site/docs/actions/wallet/L1/writeProveWithdrawalTransaction.md
@@ -1,6 +1,6 @@
 # writeProveWithdrawalTransaction
 
-Excutes a [proveWithdrawalTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L208) call to the `OptimismPortal` contract.
+Executes a [proveWithdrawalTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L208) call to the `OptimismPortal` contract.
 
 ::: info
 This is the second step in a withdrawal flow, or more generally, an L2 -> L1 call flow.
@@ -19,7 +19,7 @@ From Viem [writeContract](https://viem.sh/docs/contract/writeContract.html#write
 
 > The `writeContract` internally sends a transaction – it **does not** validate if the contract write will succeed (the contract may throw an error). It is highly recommended to [simulate the contract write with `simulateContract`](#usage) before you execute it.
 
-In this case, you can use [simulateProveWithdrawalTransactoin](/docs/actions/public/L1/simulateProveWithdrawalTransactoin).
+In this case, you can use [simulateProveWithdrawalTransaction](/docs/actions/public/L1/simulateProveWithdrawalTransaction).
 
 :::
 


### PR DESCRIPTION
I reviewed the entire repository, no more typos found in docs. 
Hope this helps streamline the project!
Best regards,
Bilogweb3