### PR TITLE
Typo Fix in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - fa49872: Update minGasLimit to be type number for consistency with ABI
 - 745a65a: Fix getTransactionHash to use un-decorated function for better tree shaking
 - 7a21a29: readFinalizedWithdrawals, txReceipt to getDeposits and getWithdrawals
-- 7d16f9b: Actions now receive contract addresses instead of L2 config objects for simplicty and Viem upstream compatibility. op-viem/chains now eexports addresses objects that be spread into actions to pass the required address.
+- 7d16f9b: Actions now receive contract addresses instead of L2 config objects for simplicity and Viem upstream compatibility. op-viem/chains now eexports addresses objects that be spread into actions to pass the required address.
 
   Previously
 


### PR DESCRIPTION
## Typo Fix in `CHANGELOG.md`

This pull request addresses a typo in the `CHANGELOG.md` file. The word "simplicty" has been corrected to "simplicity," and the word "eexports" has been corrected to "exports."

### Changes:
- Fixed the typo from "simplicty" to "simplicity."


### Checklist:
- [x] Corrected the typographical errors.
- [x] Changes reviewed and tested.
