### PR TITLE
Fix typos in documentation

### DIFF
--- a/site/docs/actions/wallet/L1/writeDepositTransaction.md
+++ b/site/docs/actions/wallet/L1/writeDepositTransaction.md
@@ -1,6 +1,6 @@
 # writeDepositTransaction
 
-Excutes a [depositTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L374) call to the [`OptimismPortal`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol) contract.
+Executes a [depositTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L374) call to the [`OptimismPortal`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol) contract.
 
 Unlike [writeSendMessage](docs/actions/wallet/L1/writeSendMessage), using this call does not offer replayability on L2 in the case the L2 tx fails. But this call has the advantage that, if the caller is an EOA, msg.sender of the L2 tx will be the caller address. Allowing users to fully tranasact on L2 from L1, which is a critical security property.
 

--- a/site/docs/actions/wallet/L1/writeProveWithdrawalTransaction.md
+++ b/site/docs/actions/wallet/L1/writeProveWithdrawalTransaction.md
@@ -1,6 +1,6 @@
 # writeProveWithdrawalTransaction
 
-Excutes a [proveWithdrawalTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L208) call to the `OptimismPortal` contract.
+Executes a [proveWithdrawalTransaction](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L208) call to the `OptimismPortal` contract.
 
 ::: info
 This is the second step in a withdrawal flow, or more generally, an L2 -> L1 call flow.

--- a/site/docs/actions/wallet/L1/writeSendMessage.md
+++ b/site/docs/actions/wallet/L1/writeSendMessage.md
@@ -1,6 +1,6 @@
 # writeSendMessage
 
-Excutes a [sendMessage](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol#L180) call to the [`L1CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol) contract. This is a fairly low level function and generally it will be more convenient to use [`writeContractDeposit`](/docs/actions/wallet/L1/writeContractDeposit).
+Executes a [sendMessage](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol#L180) call to the [`L1CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol) contract. This is a fairly low level function and generally it will be more convenient to use [`writeContractDeposit`](/docs/actions/wallet/L1/writeContractDeposit).
 
 ::: warning
 

--- a/src/actions/public/L1/simulateFinalizeWithdrawalTransaction.test.ts
+++ b/src/actions/public/L1/simulateFinalizeWithdrawalTransaction.test.ts
@@ -6,7 +6,7 @@ import { type FinalizeWithdrawalTransactionParameters } from '../../wallet/L1/wr
 import { simulateFinalizeWithdrawalTransaction } from './simulateFinalizeWithdrawalTransaction.js'
 
 // From https://etherscan.io/tx/0xcb571be93844895a45a4cf70cc4424fcc6ccf55dd4c14759da1efd57fa593ac5
-test('succesfully submits finalizeWithdrawalTransaction', async () => {
+test('successfully submits finalizeWithdrawalTransaction', async () => {
   const withdrawal: FinalizeWithdrawalTransactionParameters = {
     nonce: 1766847064778384329583297500742918515827483896875618958121606201292642114n,
     sender: '0x54392fc895e6e44538975272E0dD7335fCcC9045',

--- a/src/actions/public/getProof.ts
+++ b/src/actions/public/getProof.ts
@@ -21,7 +21,7 @@ export type StorageProof = {
   proof: Hex[]
 }
 
-// NOTE(wilson): This should be suported in viem but isn't currently
+// NOTE(wilson): This should be supported in viem but isn't currently
 export async function getProof<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
   { address, storageKeys, block }: GetProofParameters,

--- a/src/actions/wallet/L1/writeFinalizeWithdrawalTransaction.test.ts
+++ b/src/actions/wallet/L1/writeFinalizeWithdrawalTransaction.test.ts
@@ -9,7 +9,7 @@ import {
 } from './writeFinalizeWithdrawalTransaction.js'
 
 // From https://etherscan.io/tx/0x33b540f3ae33049ecb19c83a62fe15ad41dc38ccce4cf0eaf92c55431031f1b5
-test('succesfully submits finalizeWithdrawalTransaction', async () => {
+test('successfully submits finalizeWithdrawalTransaction', async () => {
   const withdrawal: FinalizeWithdrawalTransactionParameters = {
     nonce: 1766847064778384329583297500742918515827483896875618958121606201292641795n,
     sender: '0x02f086dBC384d69b3041BC738F0a8af5e49dA181',


### PR DESCRIPTION
1. Fixed "Excutes" to "Executes" in the `writeDepositTransaction.md`, `writeProveWithdrawalTransaction.md`, and `writeSendMessage.md` documentation files.
2. Corrected "succesfully" to "successfully" in `simulateFinalizeWithdrawalTransaction.test.ts` and `writeFinalizeWithdrawalTransaction.test.ts` test files.
3. Fixed "suport" to "support" in `getProof.ts`.
