### PR TITLE
docs: fixed incorrect closing tag for paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   Viem Extension for OP Stack Chains
-<p>
+</p>
 
 <br>
 


### PR DESCRIPTION
<img width="358" alt="Снимок экрана 2025-03-06 в 15 29 10" src="https://github.com/user-attachments/assets/1867e5e3-d91b-44d5-a868-db8169dfe4a9" />

I’ve corrected an issue in the HTML code where the closing tag for the paragraph was incorrectly written as `<p>`.
It should be `</p>`.

Now the code is properly formatted and works as expected.