### PR TITLE
feat: add OP Stack address alias utilities

### DIFF
--- a/.changeset/cold-mice-rhyme.md
+++ b/.changeset/cold-mice-rhyme.md
@@ -1,0 +1,5 @@
+---
+'op-viem': minor
+---
+
+Added `applyL1ToL2Alias`, `undoL1ToL2Alias`, and `L1_TO_L2_ALIAS_OFFSET` exports for working with OP Stack address aliasing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type {
 export { type OpStackL2ChainContracts, opStackL2ChainContracts, OpStackL2Contract } from './types/opStackContracts.js'
 export type { MessagePassedEvent } from './types/withdrawal.js'
 export type { WithdrawETHParameters, WithdrawToParameters } from './types/withdrawTo.js'
+export { applyL1ToL2Alias, L1_TO_L2_ALIAS_OFFSET, undoL1ToL2Alias } from './utils/addressAlias.js'
 export type { GetDepositTransactionParams } from './utils/getDepositTransaction.js'
 export { getDepositTransaction } from './utils/getDepositTransaction.js'
 export { getL2HashFromL1DepositInfo } from './utils/getL2HashFromL1DepositInfo.js'

--- a/src/utils/addressAlias.test.ts
+++ b/src/utils/addressAlias.test.ts
@@ -1,0 +1,39 @@
+import {
+  applyL1ToL2Alias as optimismApplyL1ToL2Alias,
+  undoL1ToL2Alias as optimismUndoL1ToL2Alias,
+} from '@eth-optimism/core-utils'
+import { expect, test } from 'vitest'
+import { applyL1ToL2Alias, undoL1ToL2Alias } from './addressAlias.js'
+
+test('applyL1ToL2Alias matches optimism core-utils', () => {
+  const address = '0x1234567890abcdef1234567890abcdef12345678'
+
+  expect(applyL1ToL2Alias(address)).toEqual(
+    optimismApplyL1ToL2Alias(address),
+  )
+})
+
+test('undoL1ToL2Alias matches optimism core-utils', () => {
+  const aliased = optimismApplyL1ToL2Alias(
+    '0x1234567890abcdef1234567890abcdef12345678',
+  )
+
+  expect(undoL1ToL2Alias(aliased)).toEqual(
+    optimismUndoL1ToL2Alias(aliased),
+  )
+})
+
+test('undoL1ToL2Alias reverses applyL1ToL2Alias', () => {
+  const address = '0x9999999999999999999999999999999999999999'
+
+  expect(undoL1ToL2Alias(applyL1ToL2Alias(address))).toEqual(address)
+})
+
+test('throws on invalid addresses', () => {
+  expect(() => applyL1ToL2Alias('0x1234')).toThrowError(
+    'not a valid address: 0x1234',
+  )
+  expect(() => undoL1ToL2Alias('0x1234')).toThrowError(
+    'not a valid address: 0x1234',
+  )
+})

--- a/src/utils/addressAlias.ts
+++ b/src/utils/addressAlias.ts
@@ -1,0 +1,37 @@
+import { type Address, getAddress, type Hex, hexToBigInt, isAddress, pad, toHex } from 'viem'
+
+export const L1_TO_L2_ALIAS_OFFSET = '0x1111000000000000000000000000000000001111' as const satisfies Hex
+
+const addressModulo = hexToBigInt('0x10000000000000000000000000000000000000000')
+
+function assertAddress(address: string): asserts address is Address {
+  if (!isAddress(address)) {
+    throw new Error(`not a valid address: ${address}`)
+  }
+}
+
+function bigintToAddress(value: bigint) {
+  return getAddress(pad(toHex(value % addressModulo), { size: 20 }))
+}
+
+/**
+ * Applies the L1 => L2 aliasing scheme to an address.
+ */
+export function applyL1ToL2Alias(address: string): string {
+  assertAddress(address)
+
+  return bigintToAddress(
+    hexToBigInt(address) + hexToBigInt(L1_TO_L2_ALIAS_OFFSET),
+  )
+}
+
+/**
+ * Reverses the L1 => L2 aliasing scheme from an address.
+ */
+export function undoL1ToL2Alias(address: string): string {
+  assertAddress(address)
+
+  return bigintToAddress(
+    hexToBigInt(address) - hexToBigInt(L1_TO_L2_ALIAS_OFFSET) + addressModulo,
+  )
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { applyL1ToL2Alias, L1_TO_L2_ALIAS_OFFSET, undoL1ToL2Alias } from './addressAlias.js'
 export { parseOpaqueData } from './getArgsFromTransactionDepositedOpaqueData.js'
 export type { GetDepositTransactionParams } from './getDepositTransaction.js'
 export { getDepositTransaction } from './getDepositTransaction.js'


### PR DESCRIPTION
## Summary
- add `applyL1ToL2Alias`, `undoL1ToL2Alias`, and `L1_TO_L2_ALIAS_OFFSET` utility exports
- expose the new alias helpers from both the root package entrypoint and `op-viem/utils`
- add regression tests that compare the implementation against `@eth-optimism/core-utils`

## Problem
Issue #117 asks for helpers that compute the aliased L2 `msg.sender` for L1 contract callers.

Today op-viem mentions address aliasing in deposit docs and runtime errors, but it does not provide a first-class helper for users who want to predict or reverse the aliased address.

## Solution
This PR adds utility functions that mirror the OP Stack aliasing scheme:
- `applyL1ToL2Alias(address)`
- `undoL1ToL2Alias(address)`
- `L1_TO_L2_ALIAS_OFFSET`

The implementation follows the same offset-based scheme used in the OP Stack reference utilities and validates addresses before transforming them.

## Verification
- `./node_modules/.bin/vitest run src/utils/addressAlias.test.ts`
- `./node_modules/.bin/dprint fmt src/utils/addressAlias.ts src/utils/addressAlias.test.ts src/utils/index.ts src/index.ts`
- `./node_modules/.bin/biome check src/utils/addressAlias.ts src/utils/addressAlias.test.ts src/utils/index.ts src/index.ts`

Closes #117
